### PR TITLE
feat: Adding support for Adult Festa Rocket+1D

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -1897,7 +1897,8 @@
           "Bach smart",
           "CycSA",
           "UFOSA",
-          "VorzePiston"
+          "VorzePiston",
+          "ROCKET"
         ],
         "services": {
           "40ee1111-63ec-4b7f-8ce7-712efd55b90e": {
@@ -1918,6 +1919,22 @@
           ],
           "name": {
             "en-us": "Vorze Bach"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                100
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "ROCKET"
+          ],
+          "name": {
+            "en-us": "Adult Festa Rocket"
           },
           "messages": {
             "VibrateCmd": {

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -1316,6 +1316,7 @@ protocols:
         - CycSA
         - UFOSA
         - VorzePiston
+        - ROCKET
       services:
         40ee1111-63ec-4b7f-8ce7-712efd55b90e:
           tx: 40ee2222-63ec-4b7f-8ce7-712efd55b90e
@@ -1332,7 +1333,16 @@ protocols:
           VibrateCmd:
             FeatureCount: 1
             StepCount:
-             - 100
+              - 100
+      - identifier:
+          - ROCKET
+        name:
+          en-us: Adult Festa Rocket
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 100
       - identifier:
           - CycSA
         name:


### PR DESCRIPTION
Is there a typo in that vendor name? Nope... it really is festa...
  https://www.afesta.tv/gekisin/index2.html

As we know, Vorze products are always a little awkward due
to the device type being required in the control messages
(the Rocket+1D is 0x07), but this device was extra awkward
as it required writeWithResponse messages too.