### PR TITLE
feat: Better Vibratissimo support

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -1032,6 +1032,12 @@
             "txmode": "00001524-1212-efde-1523-785feabcd123",
             "txvibrate": "00001526-1212-efde-1523-785feabcd123",
             "rx": "00001527-1212-efde-1523-785feabcd123"
+          },
+          "0000180a-0000-1000-8000-00805f9b34fb": {
+            "rxblemodel": "00002a24-0000-1000-8000-00805f9b34fb"
+          },
+          "0000180f-0000-1000-8000-00805f9b34fb": {
+            "rxblebattery": "00002a19-0000-1000-8000-00805f9b34fb"
           }
         }
       },
@@ -1040,6 +1046,8 @@
           "en-us": "Vibratissimo Device"
         },
         "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
           "VibrateCmd": {
             "FeatureCount": 1,
             "StepCount": [
@@ -1047,7 +1055,50 @@
             ]
           }
         }
-      }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Licker",
+            "SecretKiss",
+            "Womenizer"
+          ],
+          "name": {
+            "en-us": "Vibratissimo Licker"
+          },
+          "messages": {
+            "BatteryLevelCmd": {},
+            "RSSILevelCmd": {},
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                255,
+                255
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Rabbit"
+          ],
+          "name": {
+            "en-us": "Vibratissimo Rabbit"
+          },
+          "messages": {
+            "BatteryLevelCmd": {},
+            "RSSILevelCmd": {},
+            "VibrateCmd": {
+              "FeatureCount": 3,
+              "StepCount": [
+                255,
+                255,
+                2
+              ]
+            }
+          }
+        }
+      ]
     },
     "wevibe": {
       "btle": {

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -775,14 +775,50 @@ protocols:
           txmode: 00001524-1212-efde-1523-785feabcd123
           txvibrate: 00001526-1212-efde-1523-785feabcd123
           rx: 00001527-1212-efde-1523-785feabcd123
+        # Device info service
+        0000180a-0000-1000-8000-00805f9b34fb:
+          rxblemodel: 00002a24-0000-1000-8000-00805f9b34fb
+        # Battery service
+        0000180f-0000-1000-8000-00805f9b34fb:
+          rxblebattery: 00002a19-0000-1000-8000-00805f9b34fb
     defaults:
       name:
         en-us: Vibratissimo Device
       messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
         VibrateCmd:
           FeatureCount: 1
           StepCount:
             - 255
+    configurations:
+      - identifier:
+          - Licker
+          - SecretKiss
+          - Womenizer
+        name:
+          en-us: Vibratissimo Licker
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 255
+              - 255
+      - identifier:
+          - Rabbit
+        name:
+          en-us: Vibratissimo Rabbit
+        messages:
+          BatteryLevelCmd: {}
+          RSSILevelCmd: {}
+          VibrateCmd:
+            FeatureCount: 3
+            StepCount:
+              - 255
+              - 255
+              - 02
   wevibe:
     btle:
       names:

--- a/buttplug/src/device/mod.rs
+++ b/buttplug/src/device/mod.rs
@@ -43,6 +43,7 @@ pub enum Endpoint {
   Rx,
   RxAccel,
   RxBLEBattery,
+  RxBLEModel,
   RxPressure,
   RxTouch,
   Tx,

--- a/buttplug/src/device/protocol/vibratissimo.rs
+++ b/buttplug/src/device/protocol/vibratissimo.rs
@@ -1,16 +1,20 @@
 use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
 use crate::{
-  core::messages::{
-    self, ButtplugDeviceCommandMessageUnion, ButtplugDeviceMessage, DeviceMessageAttributesMap,
-    VibrateCmd, VibrateSubcommand,
+  core::{
+    errors::ButtplugError,
+    messages::{
+      self, ButtplugDeviceCommandMessageUnion, ButtplugDeviceMessage, DeviceMessageAttributesMap,
+      VibrateCmd, VibrateSubcommand,
+    },
   },
   device::{
     protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
-    DeviceImpl, DeviceWriteCmd, Endpoint,
+    DeviceImpl, DeviceReadCmd, DeviceWriteCmd, Endpoint,
   },
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use futures::future::BoxFuture;
 
 #[derive(ButtplugProtocolProperties)]
 pub struct Vibratissimo {
@@ -32,6 +36,21 @@ impl ButtplugProtocol for Vibratissimo {
       message_attributes,
       stop_commands: manager.get_stop_commands(),
       manager: Arc::new(Mutex::new(manager)),
+    })
+  }
+
+  fn initialize(
+    device_impl: Arc<DeviceImpl>,
+  ) -> BoxFuture<'static, Result<Option<String>, ButtplugError>> {
+    Box::pin(async move {
+
+      let mut name = device_impl.name.clone();
+      let result = device_impl.read_value(DeviceReadCmd::new(Endpoint::RxBLEModel, 128, 500)).await;
+      if result.is_ok() {
+        name = String::from_utf8(result.unwrap().data().to_vec()).unwrap_or(device_impl.name.clone());
+      }
+
+      Ok(Some(name))
     })
   }
 }
@@ -59,24 +78,28 @@ impl ButtplugProtocolCommandHandler for Vibratissimo {
     // Store off result before the match, so we drop the lock ASAP.
     let manager = self.manager.clone();
     Box::pin(async move {
-      let result = manager.lock().await.update_vibration(&message, false)?;
+      let result = manager.lock().await.update_vibration(&message, true)?;
       let mut fut_vec = vec![];
       if let Some(cmds) = result {
-        // We have something to write, so push our mode command.
+        let mut data: Vec<u8> = Vec::new();
+        for i in 0..cmds.len() {
+          data.push( cmds[i].unwrap_or(0) as u8 );
+        }
+        if data.len() == 1 {
+          data.push( 0x00 );
+        }
+
+        // Put the device in write mode
         fut_vec.push(device.write_value(DeviceWriteCmd::new(
           Endpoint::TxMode,
           vec![0x03, 0xff],
           false,
         )));
-        for cmd in cmds.iter() {
-          if let Some(speed) = cmd {
-            fut_vec.push(device.write_value(DeviceWriteCmd::new(
-              Endpoint::TxVibrate,
-              vec![*speed as u8, 0x00],
-              false,
-            )));
-          }
-        }
+        fut_vec.push(device.write_value(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          data,
+          false,
+        )));
       }
       // TODO Just use join_all here
       for fut in fut_vec {
@@ -98,7 +121,7 @@ mod test {
   };
 
   #[test]
-  pub fn test_vibratissimo_protocol() {
+  pub fn test_vibratissimo_protocol_default() {
     async_manager::block_on(async move {
       let (device, test_device) = new_bluetoothle_test_device("Vibratissimo").await.unwrap();
       let command_receiver_vibrate = test_device
@@ -107,18 +130,11 @@ mod test {
       let command_receiver_mode = test_device
         .get_endpoint_receiver(&Endpoint::TxMode)
         .unwrap();
+
       device
         .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
         .await
         .unwrap();
-      check_test_recv_value(
-        &command_receiver_mode,
-        DeviceImplCommand::Write(DeviceWriteCmd::new(
-          Endpoint::TxMode,
-          vec![0x03, 0xff],
-          false,
-        )),
-      );
       check_test_recv_value(
         &command_receiver_vibrate,
         DeviceImplCommand::Write(DeviceWriteCmd::new(
@@ -127,17 +143,7 @@ mod test {
           false,
         )),
       );
-      // Since we only created one subcommand, we should only receive one command.
-      device
-        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
-        .await
-        .unwrap();
-      assert!(check_test_recv_empty(&command_receiver_mode));
       assert!(check_test_recv_empty(&command_receiver_vibrate));
-      device
-        .parse_message(StopDeviceCmd::new(0).into())
-        .await
-        .unwrap();
       check_test_recv_value(
         &command_receiver_mode,
         DeviceImplCommand::Write(DeviceWriteCmd::new(
@@ -146,6 +152,20 @@ mod test {
           false,
         )),
       );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      assert!(check_test_recv_empty(&command_receiver_mode));
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
       check_test_recv_value(
         &command_receiver_vibrate,
         DeviceImplCommand::Write(DeviceWriteCmd::new(
@@ -154,6 +174,227 @@ mod test {
           false,
         )),
       );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+    });
+  }
+
+  #[test]
+  #[ignore] // Need to be able to set BLE model info to be read on test device
+  pub fn test_vibratissimo_protocol_licker() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("Vibratissimo").await.unwrap();
+      let command_receiver_vibrate = test_device
+          .get_endpoint_receiver(&Endpoint::TxVibrate)
+          .unwrap();
+      let command_receiver_mode = test_device
+          .get_endpoint_receiver(&Endpoint::TxMode)
+          .unwrap();
+
+      assert!(check_test_recv_empty(&command_receiver_mode));
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x80, 0x00],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(1, 1.0)]).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x80, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+          .await
+          .unwrap();
+      assert!(check_test_recv_empty(&command_receiver_mode));
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      device
+          .parse_message(StopDeviceCmd::new(0).into())
+          .await
+          .unwrap();
+
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x0, 0x0],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+    });
+  }
+
+  #[test]
+  #[ignore] // Need to be able to set BLE model info to be read on test device
+  pub fn test_vibratissimo_protocol_rabbit() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("Vibratissimo").await.unwrap();
+      let command_receiver_vibrate = test_device
+          .get_endpoint_receiver(&Endpoint::TxVibrate)
+          .unwrap();
+      let command_receiver_mode = test_device
+          .get_endpoint_receiver(&Endpoint::TxMode)
+          .unwrap();
+
+      assert!(check_test_recv_empty(&command_receiver_mode));
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x80, 0x00, 0x0],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(1, 1.0)]).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x80, 0xff, 0x0],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(2, 1.0)]).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x80, 0xff, 0x02],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+          .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+          .await
+          .unwrap();
+      assert!(check_test_recv_empty(&command_receiver_mode));
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+
+      device
+          .parse_message(StopDeviceCmd::new(0).into())
+          .await
+          .unwrap();
+      check_test_recv_value(
+        &command_receiver_vibrate,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxVibrate,
+          vec![0x0, 0x0, 0x0],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_vibrate));
+      check_test_recv_value(
+        &command_receiver_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::TxMode,
+          vec![0x03, 0xff],
+          false,
+        )),
+      );
+      assert!(check_test_recv_empty(&command_receiver_mode));
     });
   }
 }


### PR DESCRIPTION
This change uses the device model name to identify the
type of Vibratissimo device, allowing 2 or 3 actuator
devices to be properly controlled