### PR TITLE
feat: More Lovense device config

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -67,6 +67,14 @@
           "52300001-0023-4bd4-bbd5-a6920e4c5653": {
             "tx": "52300002-0023-4bd4-bbd5-a6920e4c5653",
             "rx": "52300003-0023-4bd4-bbd5-a6920e4c5653"
+          },
+          "46300001-0023-4bd4-bbd5-a6920e4c5653": {
+            "tx": "46300002-0023-4bd4-bbd5-a6920e4c5653",
+            "rx": "46300003-0023-4bd4-bbd5-a6920e4c5653"
+          },
+          "50300011-0023-4bd4-bbd5-a6920e4c5653": {
+            "tx": "50300012-0023-4bd4-bbd5-a6920e4c5653",
+            "rx": "50300013-0023-4bd4-bbd5-a6920e4c5653"
           }
         }
       },
@@ -107,7 +115,8 @@
                 20,
                 20
               ]
-            }
+            },
+            "BatteryLevelCmd": {}
           }
         },
         {
@@ -124,7 +133,8 @@
               "StepCount": [
                 20
               ]
-            }
+            },
+            "BatteryLevelCmd": {}
           }
         },
         {
@@ -198,6 +208,14 @@
           "name": {
             "en-us": "Loveai Dolp"
           }
+        },
+        {
+          "identifier": [
+            "F"
+          ],
+          "name": {
+            "en-us": "Lovense Blast"
+          }
         }
       ]
     },
@@ -242,7 +260,8 @@
                 20,
                 20
               ]
-            }
+            },
+            "BatteryLevelCmd": {}
           }
         },
         {
@@ -258,7 +277,8 @@
               "StepCount": [
                 20
               ]
-            }
+            },
+            "BatteryLevelCmd": {}
           }
         },
         {
@@ -323,6 +343,22 @@
           ],
           "name": {
             "en-us": "Lovense Diamo"
+          }
+        },
+        {
+          "identifier": [
+            "ToyS"
+          ],
+          "name": {
+            "en-us": "Loveai Dolp"
+          }
+        },
+        {
+          "identifier": [
+            "F"
+          ],
+          "name": {
+            "en-us": "Lovense Blast"
           }
         }
       ]

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -184,6 +184,12 @@ protocols:
         52300001-0023-4bd4-bbd5-a6920e4c5653: # Diamo
           tx: 52300002-0023-4bd4-bbd5-a6920e4c5653
           rx: 52300003-0023-4bd4-bbd5-a6920e4c5653
+        46300001-0023-4bd4-bbd5-a6920e4c5653: # Blast
+          tx: 46300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 46300003-0023-4bd4-bbd5-a6920e4c5653
+        50300011-0023-4bd4-bbd5-a6920e4c5653: # Edge2 paired
+          tx: 50300012-0023-4bd4-bbd5-a6920e4c5653
+          rx: 50300013-0023-4bd4-bbd5-a6920e4c5653
     defaults:
       name:
         en-us: Lovense Device
@@ -210,6 +216,7 @@ protocols:
             StepCount:
               - 20
               - 20
+          BatteryLevelCmd: {}
       - identifier:
           - A
           - C
@@ -220,6 +227,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 20
+          BatteryLevelCmd: {}
       - identifier:
           - L
         name:
@@ -256,6 +264,10 @@ protocols:
           - ToyS
         name:
           en-us: Loveai Dolp
+      - identifier:
+          - F
+        name:
+          en-us: Lovense Blast
   lovense-connect-service:
     lovense-connect-service:
       exists: true
@@ -287,6 +299,7 @@ protocols:
             StepCount:
               - 20
               - 20
+          BatteryLevelCmd: {}
       - identifier:
           - Nora
         name:
@@ -296,6 +309,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 20
+          BatteryLevelCmd: {}
       - identifier:
           - Ambi
         name:
@@ -328,6 +342,14 @@ protocols:
           - Diamo
         name:
           en-us: Lovense Diamo
+      - identifier:
+          - ToyS
+        name:
+          en-us: Loveai Dolp
+      - identifier:
+          - F
+        name:
+          en-us: Lovense Blast
   xinput:
     # This will actually be ANY gamepad that supports XInput. XInput
     # is its own connector type, so we don't have any special


### PR DESCRIPTION
Adding the Lovense Blast identifier and UUIDs
Adding the Lovense Edge2 paired UUIDs
Adding the BatteryCmd to the non-default Lovense devices
Adding the Dolp identifier to the Lovense dongle config