### PR TITLE
feat: Adding support for LoveDistance devices

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -3065,6 +3065,78 @@
           }
         }
       }
+    },
+    "lovedistance": {
+      "btle": {
+        "names": [
+          "REACH G",
+          "REACH",
+          "MAG",
+          "SPAN",
+          "RANGE"
+        ],
+        "services": {
+          "0000ff00-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ff01-0000-1000-8000-00805f9b34fb",
+            "rx": "0000ff02-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "name": {
+          "en-us": "Love Distance Device"
+        },
+        "messages": {
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              121
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "REACH G"
+          ],
+          "name": {
+            "en-us": "Love Distance Reach G"
+          }
+        },
+        {
+          "identifier": [
+            "REACH"
+          ],
+          "name": {
+            "en-us": "Love Distance Reach"
+          }
+        },
+        {
+          "identifier": [
+            "MAG"
+          ],
+          "name": {
+            "en-us": "Love Distance Mag"
+          }
+        },
+        {
+          "identifier": [
+            "SPAN"
+          ],
+          "name": {
+            "en-us": "Love Distance Span"
+          }
+        },
+        {
+          "identifier": [
+            "RANGE"
+          ],
+          "name": {
+            "en-us": "Love Distance Range"
+          }
+        }
+      ]
     }
   }
 }

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -2036,7 +2036,48 @@ protocols:
         VibrateCmd:
           FeatureCount: 1
           StepCount:
-            - 10            
+            - 10
+  lovedistance:
+    btle:
+      names:
+        - REACH G
+        - REACH
+        - MAG
+        - SPAN
+        - RANGE
+      services:
+        0000ff00-0000-1000-8000-00805f9b34fb:
+          tx: 0000ff01-0000-1000-8000-00805f9b34fb
+          rx: 0000ff02-0000-1000-8000-00805f9b34fb
+    defaults:
+      name:
+        en-us: Love Distance Device
+      messages:
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 121
+    configurations:
+      - identifier:
+          - REACH G
+        name:
+          en-us: Love Distance Reach G
+      - identifier:
+          - REACH
+        name:
+          en-us: Love Distance Reach
+      - identifier:
+          - MAG
+        name:
+          en-us: Love Distance Mag
+      - identifier:
+          - SPAN
+        name:
+          en-us: Love Distance Span
+      - identifier:
+          - RANGE
+        name:
+          en-us: Love Distance Range
   # nintendo-joycon:
   #   hid:
   #     vendor-id: 0x057e

--- a/buttplug/src/device/protocol/lovedistance.rs
+++ b/buttplug/src/device/protocol/lovedistance.rs
@@ -1,0 +1,124 @@
+use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
+use crate::{
+  core::{
+    errors::ButtplugError,
+    messages::{self, ButtplugDeviceCommandMessageUnion, DeviceMessageAttributesMap},
+  },
+  device::{
+    protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
+    DeviceImpl, DeviceWriteCmd, Endpoint,
+  },
+};
+use futures::future::BoxFuture;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(ButtplugProtocolProperties)]
+pub struct LoveDistance {
+  name: String,
+  message_attributes: DeviceMessageAttributesMap,
+  manager: Arc<Mutex<GenericCommandManager>>,
+  stop_commands: Vec<ButtplugDeviceCommandMessageUnion>,
+}
+
+impl ButtplugProtocol for LoveDistance {
+  fn new_protocol(
+    name: &str,
+    message_attributes: DeviceMessageAttributesMap,
+  ) -> Box<dyn ButtplugProtocol> {
+    let manager = GenericCommandManager::new(&message_attributes);
+
+    Box::new(Self {
+      name: name.to_owned(),
+      message_attributes,
+      stop_commands: manager.get_stop_commands(),
+      manager: Arc::new(Mutex::new(manager)),
+    })
+  }
+
+  fn initialize(
+    device_impl: Arc<DeviceImpl>,
+  ) -> BoxFuture<'static, Result<Option<String>, ButtplugError>> {
+    Box::pin(async move {
+      let msg = DeviceWriteCmd::new(Endpoint::Tx, vec![0xf3, 0, 0], false);
+      device_impl.write_value(msg).await?;
+      let msg = DeviceWriteCmd::new(Endpoint::Tx, vec![0xf4, 1], false);
+      device_impl.write_value(msg).await?;
+      Ok(None)
+    })
+  }
+}
+
+impl ButtplugProtocolCommandHandler for LoveDistance {
+  fn handle_vibrate_cmd(
+    &self,
+    device: Arc<DeviceImpl>,
+    message: messages::VibrateCmd,
+  ) -> ButtplugDeviceResultFuture {
+    let manager = self.manager.clone();
+    Box::pin(async move {
+      let result = manager.lock().await.update_vibration(&message, false)?;
+      if let Some(cmds) = result {
+        if let Some(speed) = cmds[0] {
+          device
+            .write_value(DeviceWriteCmd::new(
+              Endpoint::Tx,
+              vec![0xf3, 0x00, speed as u8],
+              false,
+            ))
+            .await?;
+        }
+      }
+
+      Ok(messages::Ok::default().into())
+    })
+  }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod test {
+  use crate::{
+    core::messages::{StopDeviceCmd, VibrateCmd, VibrateSubcommand},
+    device::{DeviceImplCommand, DeviceWriteCmd, Endpoint},
+    server::comm_managers::test::{check_test_recv_value, new_bluetoothle_test_device},
+    util::async_manager,
+  };
+
+  #[test]
+  pub fn test_lovedistance_protocol() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("REACH G").await.unwrap();
+      let command_receiver = test_device.get_endpoint_receiver(&Endpoint::Tx).unwrap();
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0xf3, 0, 0], false)),
+      );
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0xf4, 01], false)),
+      );
+
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::Tx,
+          vec![0xf3, 0, 0x3d],
+          false,
+        )),
+      );
+      // Test to make sure we handle packet IDs across protocol clones correctly.
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0xf3, 0, 0], false)),
+      );
+    });
+  }
+}

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -4,8 +4,8 @@ pub mod ankni;
 pub mod cachito;
 pub mod fleshlight_launch_helper;
 pub mod fredorch;
-pub mod hgod;
 pub mod generic_command_manager;
+pub mod hgod;
 pub mod htk_bm;
 pub mod jejoue;
 pub mod kiiroo_v2;
@@ -16,6 +16,7 @@ pub mod lelof1s;
 pub mod libo_elle;
 pub mod libo_shark;
 pub mod libo_vibes;
+pub mod lovedistance;
 pub mod lovehoney_desire;
 pub mod lovense;
 pub mod lovense_connect_service;
@@ -100,6 +101,7 @@ pub fn get_default_protocol_map() -> DashMap<String, TryCreateProtocolFunc> {
   add_to_protocol_map::<libo_shark::LiboShark>(&map, "libo-shark");
   add_to_protocol_map::<libo_vibes::LiboVibes>(&map, "libo-vibes");
   add_to_protocol_map::<lovehoney_desire::LovehoneyDesire>(&map, "lovehoney-desire");
+  add_to_protocol_map::<lovedistance::LoveDistance>(&map, "lovedistance");
   add_to_protocol_map::<lovense::Lovense>(&map, "lovense");
   add_to_protocol_map::<lovense_connect_service::LovenseConnectService>(
     &map,


### PR DESCRIPTION
Tested with the ReachG. The app detected the other models
when spoofing them with nRF Connect, so I'm confident the
rest will work.