### PR TITLE
Fix linux hidapi backend

### DIFF
--- a/buttplug/Cargo.toml
+++ b/buttplug/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 keywords = ["usb", "serial", "hardware", "bluetooth", "teledildonics"]
 edition = "2018"
 exclude = ["examples/**"]
+resolver = "2"
 
 [features]
 # Basic features
@@ -71,17 +72,12 @@ tokio = { version = "1.11.0", features = ["sync"] }
 async-stream = "0.3.2"
 prost = "0.8.0"
 tokio-util = "0.6.8"
+hidapi = { version = "1.3.0", default-features = false, features = ["linux-static-hidraw", "illumos-static-libusb"], optional = true }
 reqwest = { version = "0.11.4", optional = true, features = ["native-tls"] }
 serde-aux = "2.3.0"
 
 [target.'cfg(windows)'.dependencies]
 rusty-xinput = "1.2.0"
-
-[target.'cfg(target_os="linux")'.dependencies]
-hidapi = { version = "1.3.0", default-features = false, features = ["linux-static-hidraw"], optional = true }
-
-[target.'cfg(not(target_os="linux"))'.dependencies]
-hidapi = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["io-std", "io-util", "macros"] }

--- a/buttplug/Cargo.toml
+++ b/buttplug/Cargo.toml
@@ -66,7 +66,6 @@ tracing-subscriber = { version = "0.2.20", features = ["json"] }
 dashmap = "4.0.2"
 displaydoc = "0.2.3"
 serialport = { version = "4.0.1", optional = true }
-hidapi = { version = "1.2.6", optional = true }
 wasm-bindgen = { version = "0.2.77", optional = true }
 tokio = { version = "1.11.0", features = ["sync"] }
 async-stream = "0.3.2"
@@ -77,6 +76,12 @@ serde-aux = "2.3.0"
 
 [target.'cfg(windows)'.dependencies]
 rusty-xinput = "1.2.0"
+
+[target.'cfg(target_os="linux")'.dependencies]
+hidapi = { version = "1.3.0", default-features = false, features = ["linux-static-hidraw"], optional = true }
+
+[target.'cfg(not(target_os="linux"))'.dependencies]
+hidapi = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.11.0", features = ["io-std", "io-util", "macros"] }


### PR DESCRIPTION
This seems to fix an issue with Linux where the Lovense HID dongle isn't detected by Intiface on Linux.

**WARNING**
Due to an issue with cargo where the selective dependencies don't seem to work correctly you can only build with ``cargo +nightly -Z features=itarget build`` after applying this fix.

I don't know if this can be fixed in another way without breaking builds on the stable toolchain.
I am also only able to test this on Linux so I can't say for sure if this still works on Windows.