### PR TITLE
try reconnecting to disconnected btleplug devices

### DIFF
--- a/buttplug/src/server/comm_managers/btleplug/btleplug_adapter_task.rs
+++ b/buttplug/src/server/comm_managers/btleplug/btleplug_adapter_task.rs
@@ -212,6 +212,7 @@ impl BtleplugAdapterTask {
                 CentralEvent::DeviceDisconnected(peripheral_id) => {
                   debug!("BTLEPlug Device disconnected: {:?}", peripheral_id);
                   tried_addresses.retain(|info| info.peripheral_id != peripheral_id);
+                  self.maybe_add_peripheral(&peripheral_id, &adapter, &mut tried_addresses).await;
                 }
                 event => {
                   trace!("Unhandled btleplug central event: {:?}", event)


### PR DESCRIPTION
i don't really understand this code so it's probably a nasty hack, but this does work as intended to immediately reconnect when a device gets randomly disconnected, without waiting for it to show up in the scan (which can take many seconds).

it doesn't currently differentiate between a device being disconnected unintentionally vs intentionally, if that would be desirable (or even possible?). we might also not want to reconnect if scanning is not currently running, but i don't take that into account here.