### PR TITLE
fix: Issue #426

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config-schema.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config-schema.json
@@ -24,7 +24,13 @@
             "type": "string",
             "$ref": "#/components/uuid"
           }
-        },        
+        },
+        "required-endpoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "services": {
           "type": "object",
           "patternProperties": {

--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -3297,6 +3297,10 @@
         "advertised-services": [
           "0000180a-0000-1000-8000-00805f9b34fb"
         ],
+        "required-endpoints": [
+          "tx",
+          "command"
+        ],
         "services": {
           "00001800-0000-1000-8000-00805f9b34fb": {
             "rxblemodel": "00002a00-0000-1000-8000-00805f9b34fb"

--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -993,6 +993,100 @@
         }
       }
     },
+    "magic-motion-4": {
+      "btle": {
+        "names": [
+          "funone",
+          "Magic Sundi",
+          "Kegel Coach",
+          "Magic Lotos",
+          "nyx",
+          "umi"
+        ],
+        "services": {
+          "78667579-7b48-43db-b8c5-7928a6b0a335": {
+            "tx": "78667579-a914-49a4-8333-aa3c0cd8fedc"
+          },
+          "0000180f-0000-1000-8000-00805f9b34fb": {
+            "rxblebattery": "00002a19-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "name": {
+          "en-us": "Magic Motion V4 Device"
+        },
+        "messages": {
+          "BatteryLevelCmd": {},
+          "RSSILevelCmd": {},
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "funone"
+          ],
+          "name": {
+            "en-us": "MagicMotion Bunny"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Sundi"
+          ],
+          "name": {
+            "en-us": "MagicMotion Sundae"
+          }
+        },
+        {
+          "identifier": [
+            "Kegel Coach"
+          ],
+          "name": {
+            "en-us": "MagicMotion Kegel Coach"
+          }
+        },
+        {
+          "identifier": [
+            "Magic Lotos"
+          ],
+          "name": {
+            "en-us": "MagicMotion Lotos"
+          }
+        },
+        {
+          "identifier": [
+            "nyx"
+          ],
+          "name": {
+            "en-us": "MagicMotion Nyx"
+          }
+        },
+        {
+          "identifier": [
+            "umi"
+          ],
+          "name": {
+            "en-us": "MagicMotion Umi"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100,
+                100
+              ]
+            }
+          }
+        }
+      ]
+    },
     "mysteryvibe": {
       "btle": {
         "names": [

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -2175,6 +2175,9 @@ protocols:
         - SF *
       advertised-services:
         - 0000180a-0000-1000-8000-00805f9b34fb
+      required-endpoints:
+        - tx
+        - command
       services:
         00001800-0000-1000-8000-00805f9b34fb:
           rxblemodel: 00002a00-0000-1000-8000-00805f9b34fb

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -745,6 +745,62 @@ protocols:
           FeatureCount: 1
           StepCount:
             - 77
+  magic-motion-4:
+    btle:
+      names:
+        - funone # Bunny
+        - Magic Sundi
+        - Kegel Coach
+        - Magic Lotos
+        - nyx
+        - umi
+      services:
+        78667579-7b48-43db-b8c5-7928a6b0a335:
+          tx: 78667579-a914-49a4-8333-aa3c0cd8fedc
+        # Battery service
+        0000180f-0000-1000-8000-00805f9b34fb:
+          rxblebattery: 00002a19-0000-1000-8000-00805f9b34fb
+    defaults:
+      name:
+        en-us: Magic Motion V4 Device
+      messages:
+        BatteryLevelCmd: {}
+        RSSILevelCmd: {}
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 100
+    configurations:
+      - identifier:
+          - funone
+        name:
+          en-us: MagicMotion Bunny
+      - identifier:
+          - Magic Sundi
+        name:
+          en-us: MagicMotion Sundae
+      - identifier:
+          - Kegel Coach
+        name:
+          en-us: MagicMotion Kegel Coach
+      - identifier:
+          - Magic Lotos
+        name:
+          en-us: MagicMotion Lotos
+      - identifier:
+          - nyx
+        name:
+          en-us: MagicMotion Nyx
+      - identifier:
+          - umi
+        name:
+          en-us: MagicMotion Umi
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 100
+              - 100
   mysteryvibe:
     btle:
       names:

--- a/buttplug/src/device/configuration_manager.rs
+++ b/buttplug/src/device/configuration_manager.rs
@@ -41,6 +41,8 @@ pub struct BluetoothLESpecifier {
   names: HashSet<String>,
   #[serde(default, rename = "advertised-services")]
   advertised_services: HashSet<Uuid>,
+  #[serde(default, rename = "required-endpoints")]
+  required_endpoints: HashSet<Endpoint>,
   // Set of services that we may have gotten as part of the advertisement.
   services: HashMap<Uuid, HashMap<Endpoint, Uuid>>,
 }
@@ -92,6 +94,7 @@ impl BluetoothLESpecifier {
     BluetoothLESpecifier {
       names: name_set,
       advertised_services: service_set,
+      required_endpoints: HashSet::new(),
       services: HashMap::new(),
     }
   }

--- a/buttplug/src/device/mod.rs
+++ b/buttplug/src/device/mod.rs
@@ -450,46 +450,73 @@ impl ButtplugDevice {
     // error.
 
     match device_config_mgr.find_protocol_definitions(&device_creator.get_specifier()) {
-      Some((allow_raw_messages, config_name, config)) => {
-        // Now that we have both a possible device implementation and a
-        // configuration for that device, try to initialize the implementation.
-        // This usually means trying to connect to whatever the device is,
-        // finding endpoints, etc.
-        let device_protocol_config = DeviceProtocolConfiguration::new(
-          allow_raw_messages,
-          config.defaults().clone(),
-          config.configurations().clone(),
-        );
-        // TODO Should we even return a config from the device_config_mgr if the
-        // protocol isn't there?
-        if device_config_mgr.has_protocol(&*config_name) {
-          let device_impl = device_creator.try_create_device_impl(config).await?;
-          info!(
-            address = tracing::field::display(device_impl.address()),
-            "Found Buttplug Device {}",
-            device_impl.name()
+      Some(arr) => {
+        for (allow_raw_messages, config_name, config) in arr.iter() {
+          // Now that we have both a possible device implementation and a
+          // configuration for that device, try to initialize the implementation.
+          // This usually means trying to connect to whatever the device is,
+          // finding endpoints, etc.
+          let device_protocol_config = DeviceProtocolConfiguration::new(
+            allow_raw_messages.clone(),
+            config.defaults().clone(),
+            config.configurations().clone(),
           );
-          // If we've made it this far, we now have a connected device
-          // implementation with endpoints set up. We now need to run whatever
-          // protocol initialization might need to happen. We'll fetch a protocol
-          // creator, pass the device implementation to it, then let it do
-          // whatever it needs. For most protocols, this is a no-op. However, for
-          // devices like Lovense, some Kiiroo, etc, this can get fairly
-          // complicated.
-          let sharable_device_impl = Arc::new(device_impl);
-          let protocol_creator_func = device_config_mgr
-            .get_protocol_creator(&*config_name)
-            .expect("Already checked for protocol existence");
-          let protocol_impl =
-            protocol_creator_func(sharable_device_impl.clone(), device_protocol_config).await?;
-          Ok(Some(ButtplugDevice::new(
-            protocol_impl,
-            sharable_device_impl,
-          )))
-        } else {
-          info!("Protocol {} not available", config_name);
-          Ok(None)
+          // TODO Should we even return a config from the device_config_mgr if the
+          // protocol isn't there?
+          if device_config_mgr.has_protocol(&*config_name) {
+            debug!("Testing for protocol {}", config_name);
+            let device_impl = match device_creator.try_create_device_impl(config.clone()).await {
+              Ok(di) => di,
+              Err(err) => {
+                error!(
+                  "Failed to create device implementation with protocol {}: {:?}",
+                  config_name, err
+                );
+                continue;
+              }
+            };
+            info!(
+              address = tracing::field::display(device_impl.address()),
+              "Found Buttplug Device {} match protocol {}",
+              device_impl.name(),
+              config_name
+            );
+            // If we've made it this far, we now have a connected device
+            // implementation with endpoints set up. We now need to run whatever
+            // protocol initialization might need to happen. We'll fetch a protocol
+            // creator, pass the device implementation to it, then let it do
+            // whatever it needs. For most protocols, this is a no-op. However, for
+            // devices like Lovense, some Kiiroo, etc, this can get fairly
+            // complicated.
+            let sharable_device_impl = Arc::new(device_impl);
+            let protocol_creator_func = device_config_mgr
+              .get_protocol_creator(&*config_name)
+              .expect("Already checked for protocol existence");
+            let protocol_impl =
+              match protocol_creator_func(sharable_device_impl.clone(), device_protocol_config)
+                .await
+              {
+                Ok(pi) => pi,
+                Err(err) => {
+                  sharable_device_impl.disconnect();
+                  error!(
+                    "Failed to create protocol implementation for protocol {}: {:?}",
+                    config_name, err
+                  );
+                  continue;
+                }
+              };
+            return Ok(Some(ButtplugDevice::new(
+              protocol_impl,
+              sharable_device_impl,
+            )));
+          } else {
+            info!("Protocol {} not available", config_name);
+            return Ok(None);
+          }
         }
+        info!("No protocol were matched");
+        Ok(None)
       }
       None => Ok(None),
     }

--- a/buttplug/src/device/protocol/magic_motion_v4.rs
+++ b/buttplug/src/device/protocol/magic_motion_v4.rs
@@ -1,0 +1,136 @@
+use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
+use crate::{
+  core::messages::{self, ButtplugDeviceCommandMessageUnion, DeviceMessageAttributesMap},
+  device::{
+    protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
+    DeviceImpl,
+    DeviceWriteCmd,
+    Endpoint,
+  },
+};
+use std::sync::Arc;
+
+super::default_protocol_declaration!(MagicMotionV4);
+
+impl ButtplugProtocolCommandHandler for MagicMotionV4 {
+  fn handle_vibrate_cmd(
+    &self,
+    device: Arc<DeviceImpl>,
+    message: messages::VibrateCmd,
+  ) -> ButtplugDeviceResultFuture {
+    // Store off result before the match, so we drop the lock ASAP.
+    let manager = self.manager.clone();
+    Box::pin(async move {
+      let result = manager.lock().await.update_vibration(&message, true)?;
+      if let Some(cmds) = result {
+        let data = if cmds.len() == 1 {
+          vec![
+            0x10,
+            0xff,
+            0x04,
+            0x0a,
+            0x32,
+            0x32,
+            0x00,
+            0x04,
+            0x08,
+            cmds[0].unwrap_or(0) as u8,
+            0x64,
+            0x00,
+            0x04,
+            0x08,
+            cmds[0].unwrap_or(0) as u8,
+            0x64,
+            0x01,
+          ]
+        } else {
+          vec![
+            0x10,
+            0xff,
+            0x04,
+            0x0a,
+            0x32,
+            0x32,
+            0x00,
+            0x04,
+            0x08,
+            cmds[0].unwrap_or(0) as u8,
+            0x64,
+            0x00,
+            0x04,
+            0x08,
+            cmds[1].unwrap_or(0) as u8,
+            0x64,
+            0x01,
+          ]
+        };
+        device
+          .write_value(DeviceWriteCmd::new(Endpoint::Tx, data, true))
+          .await?;
+      }
+      Ok(messages::Ok::default().into())
+    })
+  }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod test {
+  use crate::{
+    core::messages::{StopDeviceCmd, VibrateCmd, VibrateSubcommand},
+    device::{DeviceImplCommand, DeviceWriteCmd, Endpoint},
+    server::comm_managers::test::{
+      check_test_recv_empty,
+      check_test_recv_value,
+      new_bluetoothle_test_device,
+    },
+    util::async_manager,
+  };
+
+  #[test]
+  pub fn test_magic_motion_v4_protocol() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("umi")
+        .await
+        .expect("Test, assuming infallible");
+      let command_receiver = test_device
+        .get_endpoint_receiver(&Endpoint::Tx)
+        .expect("Test, assuming infallible");
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .expect("Test, assuming infallible");
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::Tx,
+          vec![
+            0x10, 0xff, 0x04, 0x0a, 0x32, 0x32, 0x00, 0x04, 0x08, 0x32, 0x64, 0x00, 0x04, 0x08,
+            0x00, 0x64, 0x01,
+          ],
+          true,
+        )),
+      );
+      // Since we only created one subcommand, we should only receive one command.
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .expect("Test, assuming infallible");
+      assert!(check_test_recv_empty(&command_receiver));
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .expect("Test, assuming infallible");
+      check_test_recv_value(
+        &command_receiver,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(
+          Endpoint::Tx,
+          vec![
+            0x10, 0xff, 0x04, 0x0a, 0x32, 0x32, 0x00, 0x04, 0x08, 0x00, 0x64, 0x00, 0x04, 0x08,
+            0x00, 0x64, 0x01,
+          ],
+          true,
+        )),
+      );
+    });
+  }
+}

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -26,6 +26,7 @@ pub mod lovenuts;
 pub mod magic_motion_v1;
 pub mod magic_motion_v2;
 pub mod magic_motion_v3;
+pub mod magic_motion_v4;
 pub mod mannuo;
 pub mod maxpro;
 pub mod mizzzee;
@@ -130,6 +131,7 @@ pub fn get_default_protocol_map() -> DashMap<String, TryCreateProtocolFunc> {
   add_to_protocol_map::<magic_motion_v1::MagicMotionV1>(&map, "magic-motion-1");
   add_to_protocol_map::<magic_motion_v2::MagicMotionV2>(&map, "magic-motion-2");
   add_to_protocol_map::<magic_motion_v3::MagicMotionV3>(&map, "magic-motion-3");
+  add_to_protocol_map::<magic_motion_v4::MagicMotionV4>(&map, "magic-motion-4");
   add_to_protocol_map::<mannuo::ManNuo>(&map, "mannuo");
   add_to_protocol_map::<maxpro::Maxpro>(&map, "maxpro");
   add_to_protocol_map::<mizzzee::MizzZee>(&map, "mizzzee");

--- a/buttplug/src/server/device_manager_event_loop.rs
+++ b/buttplug/src/server/device_manager_event_loop.rs
@@ -228,7 +228,8 @@ impl DeviceManagerEventLoop {
           return;
         }
 
-        self.try_create_new_device(address, creator);
+        self.try_create_new_device(address.clone(), creator);
+        self.connecting_devices.remove(address.as_str());
       }
       DeviceCommunicationEvent::DeviceManagerAdded(status) => {
         self.comm_manager_scanning_statuses.push(status);
@@ -309,10 +310,7 @@ impl DeviceManagerEventLoop {
           .get(&address)
           .expect("Index must exist to get here.")
           .value();
-        self
-          .device_map
-          .remove(&device_index)
-          .expect("Remove will always work.");
+        self.device_map.remove(&device_index);
         if self
           .server_sender
           .send(DeviceRemoved::new(device_index).into())


### PR DESCRIPTION
I've broken the change up into distinct pieces so it's clearer what's related to what and why I had to make the changes.

* The first commit allows multiple matching protocols for a device to be iterated over to find the right match.
* The second commit allows a potentially matching protocol to be skipped if the device lacks a required endpoint
* The third change allows for a device previously connected to be re-connected

The overall change requires https://github.com/deviceplug/btleplug/pull/247 as my MagicMotion devices consistently
failed to find the Tx characteristic and because if the advertised services had been received without the BLE name, then
we never get enough advertising data to make the correct match until we release the connection.

Fixes #426 