### PR TITLE
Rebased multi-protocol matcher support

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -3635,7 +3635,7 @@
           "name": "Satisfyer E-Love G-Spotter",
           "messages": {
             "VibrateCmd": {
-              "FeatureCount": 2,
+              "FeatureCount": 1,
               "StepCount": [
                 100
               ]
@@ -4145,6 +4145,67 @@
           }
         }
       }
+    },
+    "hismith": {
+      "btle": {
+        "names": [
+          "HISMITH"
+        ],
+        "services": {
+          "0000ffe5-0000-1000-8000-00805f9b34fb": {
+            "tx": "0000ffe9-0000-1000-8000-00805f9b34fb"
+          },
+          "0000ff90-0000-1000-8000-00805f9b34fb": {
+            "rxblemodel": "0000ff96-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "name": "Hismith device",
+        "messages": {
+          "VibrateCmd": {
+            "FeatureCount": 1,
+            "StepCount": [
+              100
+            ]
+          }
+        }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "1001"
+          ],
+          "name": "Hismith Sex Machine"
+        },
+        {
+          "identifier": [
+            "1002"
+          ],
+          "name": "Hismith Pro Traveler"
+        },
+        {
+          "identifier": [
+            "1003"
+          ],
+          "name": "Hismith Capsule"
+        },
+        {
+          "identifier": [
+            "2001"
+          ],
+          "name": "Hismith Thrusting Cup",
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                100,
+                1
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -452,7 +452,7 @@ protocols:
             tx: 00006001-0000-1000-8000-00805f9b34fb
             txmode: 00006002-0000-1000-8000-00805f9b34fb
       defaults:
-        name: Libo Elle Device      
+        name: Libo Elle Device
         messages:
           VibrateCmd:
             FeatureCount: 1
@@ -475,7 +475,7 @@ protocols:
             tx: 00006001-0000-1000-8000-00805f9b34fb
             txmode: 00006002-0000-1000-8000-00805f9b34fb
       defaults:
-        name: Libo Shark          
+        name: Libo Shark
         messages:
           VibrateCmd:
             FeatureCount: 2
@@ -495,7 +495,7 @@ protocols:
           00006050-0000-1000-8000-00805f9b34fb:
             rxpressure: 00006051-0000-1000-8000-00805f9b34fb
       defaults:
-        name: Libo Karen        
+        name: Libo Karen
         messages: {}
   libo-vibes:
       btle:
@@ -1491,7 +1491,7 @@ protocols:
           tx: 0000ffe9-0000-1000-8000-00805f9b34fb
           rx: 0000ffe2-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Pretty Love Device      
+      name: Pretty Love Device
       messages:
         VibrateCmd:
           FeatureCount: 1
@@ -1582,7 +1582,7 @@ protocols:
         0000ffe0-0000-1000-8000-00805f9b34fb:
           tx: 0000ffe1-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Realov Device      
+      name: Realov Device
       messages:
         VibrateCmd:
           FeatureCount: 1
@@ -1670,7 +1670,7 @@ protocols:
           tx: 0000fff6-0000-1000-8000-00805f9b34fb
           rx: 0000fff8-0000-1000-8000-00805f9b34fb
     defaults:
-      name: SayberX Device      
+      name: SayberX Device
       messages: {}
     configurations:
       - identifier:
@@ -1693,7 +1693,7 @@ protocols:
         0000aaa0-0000-1000-8000-00805f9b34fb:
           tx: 0000aaa1-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Muse Device      
+      name: Muse Device
       messages:
         VibrateCmd:
           FeatureCount: 1
@@ -1720,7 +1720,7 @@ protocols:
           # I figure we'll add them as support for those sensor
           # types is added to Buttplug
     defaults:
-      name: Lelo F1s 
+      name: Lelo F1s
       messages:        
         VibrateCmd:
           FeatureCount: 2
@@ -1760,7 +1760,7 @@ protocols:
         0000ff00-0000-1000-8000-00805f9b34fb:
           tx: 0000ff01-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Aneros Vivi         
+      name: Aneros Vivi
       messages:
         VibrateCmd:
           FeatureCount: 2
@@ -1777,7 +1777,7 @@ protocols:
         0000ff00-0000-1000-8000-00805f9b34fb:
           tx: 0000ff01-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Lovehoney Device         
+      name: Lovehoney Device
       messages:
         VibrateCmd:
           FeatureCount: 2
@@ -1815,7 +1815,7 @@ protocols:
           tx: 00000a66-0000-1000-8000-00805f9b34fb
           rx: 00000a67-0000-1000-8000-00805f9b34fb
     defaults:
-      name: Twerking Butt         
+      name: Twerking Butt
       messages: {}
         # Vibration and Rotation protocols still need to be establised
         # Twerk mode will be represented as a vibrator
@@ -1827,7 +1827,7 @@ protocols:
         6e400001-b5a3-f393-e0a9-e50e24dcca9e:
           tx: 6e400002-b5a3-f393-e0a9-e50e24dcca9e
     defaults:
-      name: MaxPro 2         
+      name: MaxPro 2
       messages:
         VibrateCmd:
           FeatureCount: 1
@@ -1860,7 +1860,7 @@ protocols:
           tx: 1775ff55-6b43-439b-877c-060f2d9bed07
           # There are 5 other characteristics, all of which seem to be unused.
     defaults:
-      name: The Handy         
+      name: The Handy
       messages:
         LinearCmd:
           FeatureCount: 1
@@ -2448,7 +2448,7 @@ protocols:
         name: Satisfyer E-Love G-Spotter
         messages:
           VibrateCmd:
-            FeatureCount: 2 # 4?
+            FeatureCount: 1 # 4?
             StepCount:
               - 100
               # - 100 e-amplitude
@@ -2770,6 +2770,41 @@ protocols:
           FeatureCount: 1
           StepCount:
             - 3
+  hismith:
+    btle:
+      names:
+        - HISMITH
+      services:
+        0000ffe5-0000-1000-8000-00805f9b34fb:
+          tx: 0000ffe9-0000-1000-8000-00805f9b34fb
+        0000ff90-0000-1000-8000-00805f9b34fb:
+          rxblemodel: 0000ff96-0000-1000-8000-00805f9b34fb
+    defaults:
+      name: Hismith device
+      messages:
+        VibrateCmd:
+          FeatureCount: 1
+          StepCount:
+            - 100
+    configurations:
+      - identifier:
+          - "1001"
+        name: Hismith Sex Machine
+      - identifier:
+          - "1002"
+        name: Hismith Pro Traveler
+      - identifier:
+          - "1003"
+        name: Hismith Capsule
+      - identifier:
+          - "2001"
+        name: Hismith Thrusting Cup
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 100 # Oscillate
+              - 1 # Vibe
   # nintendo-joycon:
   #   hid:
   #     vendor-id: 0x057e

--- a/buttplug/examples/04-device-control.rs
+++ b/buttplug/examples/04-device-control.rs
@@ -18,6 +18,7 @@ use buttplug::client::{
 use futures::StreamExt;
 use futures_timer::Delay;
 use std::{sync::Arc, time::Duration};
+use tracing::Level;
 
 async fn device_control_example() {
   // Onto the final example! Controlling devices.
@@ -143,5 +144,9 @@ async fn device_control_example() {
 
 #[tokio::main]
 async fn main() {
+
+  tracing_subscriber::fmt()
+      // filter spans/events with level TRACE or higher.
+      .with_max_level(Level::DEBUG).init();
   device_control_example().await;
 }

--- a/buttplug/src/device/mod.rs
+++ b/buttplug/src/device/mod.rs
@@ -494,7 +494,10 @@ impl ButtplugDevice {
       {
         Ok(pi) => pi,
         Err(err) => {
-          sharable_device_impl.disconnect();
+          let res = sharable_device_impl.disconnect().await;
+          if res.is_err() {
+            trace!("Device disconnect error: {:?}", res.err());
+          }
           error!(
                     "Failed to create protocol implementation for protocol {}: {:?}",
                     "how-do-we-get-this-now?", err

--- a/buttplug/src/device/protocol/hismith.rs
+++ b/buttplug/src/device/protocol/hismith.rs
@@ -3,15 +3,72 @@ use crate::{
   core::messages::{self, ButtplugDeviceCommandMessageUnion},
   device::{
     protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
-    configuration_manager::{ProtocolDeviceAttributes, DeviceAttributesBuilder},
+    configuration_manager::{ProtocolDeviceAttributes, DeviceAttributesBuilder, ProtocolAttributesIdentifier},
     DeviceImpl,
+    DeviceReadCmd,
     DeviceWriteCmd,
     Endpoint,
   },
 };
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
-super::default_protocol_declaration!(Hismith, "hismith");
+pub struct Hismith {
+  device_attributes: ProtocolDeviceAttributes,
+  manager: Arc<Mutex<GenericCommandManager>>,
+  stop_commands: Vec<ButtplugDeviceCommandMessageUnion>,
+}
+
+impl Hismith {
+  const PROTOCOL_IDENTIFIER: &'static str = "hismith";
+
+  fn new(
+    device_attributes: ProtocolDeviceAttributes,
+  ) -> Self {
+    let manager = GenericCommandManager::new(&device_attributes);
+    Self {
+      device_attributes,
+      stop_commands: manager.stop_commands(),
+      manager: Arc::new(Mutex::new(manager)),
+    }
+  }
+}
+
+#[derive(Default, Debug)]
+pub struct HismithFactory {}
+
+impl ButtplugProtocolFactory for HismithFactory {
+  fn try_create(
+    &self,
+    device_impl: Arc<crate::device::DeviceImpl>,
+    builder: DeviceAttributesBuilder,
+  ) -> futures::future::BoxFuture<
+    'static,
+    Result<Box<dyn ButtplugProtocol>, crate::core::errors::ButtplugError>,
+  > {
+    Box::pin(async move {
+      let result = device_impl
+          .read_value(DeviceReadCmd::new(Endpoint::RxBLEModel, 128, 500))
+          .await?;
+      let device_identifier = result.data().into_iter().map( |b| format!("{:02x}", b) ).collect::<String>();
+      info!(
+        "Hismith Device Identifier: {}",
+        device_identifier
+      );
+      let device_attributes = builder.create(device_impl.address(), &ProtocolAttributesIdentifier::Identifier(device_identifier), &device_impl.endpoints())?;
+      let device = Hismith::new(device_attributes);
+      Ok(Box::new(device) as Box<dyn ButtplugProtocol>)
+    })
+  }
+
+  fn protocol_identifier(&self) -> &'static str {
+    Hismith::PROTOCOL_IDENTIFIER
+  }
+}
+
+impl ButtplugProtocol for Hismith {}
+
+crate::default_protocol_properties_definition!(Hismith);
 
 impl ButtplugProtocolCommandHandler for Hismith {
   fn handle_vibrate_cmd(
@@ -31,6 +88,16 @@ impl ButtplugProtocolCommandHandler for Hismith {
             vec![0xAA, 0x04, speed as u8, (speed + 4) as u8],
             false,
           )));
+        }
+        if cmds.len() > 1 {
+          if let Some(speed) = cmds[1] {
+            let value = if speed == 0 { 0xf0 } else { speed };
+            fut_vec.push(device.write_value(DeviceWriteCmd::new(
+              Endpoint::Tx,
+              vec![0xAA, 0x06, value as u8, (value + 6) as u8],
+              false,
+            )));
+          }
         }
       }
       // TODO Just use join_all here


### PR DESCRIPTION
Fixes #426 

Also adds the Hismith Cup vibration support and matching config, required to test the Lovense/Folove vs Hismith conflict