### PR TITLE
chore: Update prost and prost-build to 0.11

### DIFF
--- a/buttplug/Cargo.toml
+++ b/buttplug/Cargo.toml
@@ -72,7 +72,7 @@ hidapi = { version = "1.4.1", default-features = false, features = ["linux-stati
 wasm-bindgen = { version = "0.2.80", optional = true }
 tokio = { version = "1.17.0", features = ["sync", "macros", "io-util"] }
 async-stream = "0.3.3"
-prost = "0.10.1"
+prost = "0.11"
 tokio-util = "0.7.1"
 reqwest = { version = "0.11.10", optional = true, features = ["native-tls"] }
 serde-aux = "3.0.1"
@@ -101,7 +101,7 @@ targets = []
 features = ["default", "unstable"]
 
 [build-dependencies]
-prost-build = "0.10.1"
+prost-build = "0.11"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.36.0", features = ["Devices_Bluetooth", "Foundation"] }


### PR DESCRIPTION
This fixes cross-compilation from Linux to Windows. prost-build 0.10 has
a bug that prevents it from working.

However, prost-build 0.11 comes with a new build requirement where the
environment needs to provide protoc. Previously, prost-build would try
to build protoc from source if it was not available. buttplug, in turn,
inherits this requirement as such. This may be undesirable for buttplug, so I understand if you reject this for that reason. However, it would be nice to have cross-compilation working.