### PR TITLE
[Protocol spec] Remove StepRange from Device List message example

### DIFF
--- a/spec/protocol-spec/enumeration.md
+++ b/spec/protocol-spec/enumeration.md
@@ -244,7 +244,7 @@ sequenceDiagram
           "DeviceDisplayName": "User set name",
           "DeviceMessages": {
             "LinearCmd": [ {
-              "StepRange": [0, 100],
+              "StepCount": 100,
               "FeatureDescriptor": "Stroker"
             } ],
             "StopDeviceCmd": {}


### PR DESCRIPTION
Fixes #489 by removing the `StepRange` field from the example and converting it to a `StepCount` field.

This approach was prefered as `ScalarCmd` and the rest of types of messages that accept these device arguments expect a 0.0-1.0 double as the argument, so having the real range doesn't provide a real value while the `StepCount` does unless those messages offer a way to use the devices real range.