### PR TITLE
Fix SensorIndex type

### DIFF
--- a/spec/protocol-spec/sensors.md
+++ b/spec/protocol-spec/sensors.md
@@ -43,7 +43,7 @@ sequenceDiagram
     "SensorReadCmd": {
       "Id": 1,
       "DeviceIndex": 0,
-      "SensorIndex": "0",
+      "SensorIndex": 0,
       "SensorType": "Pressure"
     }
   }


### PR DESCRIPTION
Example for `SensorReadCmd` uses a string as `SensorIndex` when it should be an integer.