### PR TITLE
Patched an issue with Lovense Connect connection issues.

### DIFF
--- a/buttplug/src/server/device/hardware/communication/lovense_connect_service/lovense_connect_service_hardware.rs
+++ b/buttplug/src/server/device/hardware/communication/lovense_connect_service/lovense_connect_service_hardware.rs
@@ -33,7 +33,7 @@ use std::{
   sync::{
     atomic::{AtomicU8, Ordering},
     Arc,
-  },
+  }, time::Duration,
 };
 use tokio::sync::broadcast;
 
@@ -93,6 +93,8 @@ impl LovenseServiceHardware {
     let battery_level_clone = battery_level.clone();
     async_manager::spawn(async move {
       loop {
+        // SutekhVRC/VibeCheck patch for delay because Lovense Connect HTTP servers crash (Perma DOS)
+        tokio::time::sleep(Duration::from_secs(1)).await;
         match get_local_info(&host).await {
           Some(info) => {
             for (_, toy) in info.data.iter() {


### PR DESCRIPTION
What:
Patched "lovense service device connection check loop" in lovense_connect_service_hardware.rs.

Why:
The connection check loop had no delay and would cause a DOS condition for the desktop Lovense Connect app in release builds of the library. The DOS condition would not happen in debug builds likely due to speed reasons.