### PR TITLE
Support Rez trance vibrator again

### DIFF
--- a/buttplug/Cargo.toml
+++ b/buttplug/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["examples/**"]
 
 [features]
 # Basic features
-default=["tokio-runtime", "client", "server", "serialize-json", "websockets", "btleplug-manager", "xinput-manager", "serial-manager", "lovense-dongle-manager", "lovense-connect-service-manager", "websocket-server-manager"]
+default=["tokio-runtime", "client", "server", "serialize-json", "websockets", "btleplug-manager", "xinput-manager", "serial-manager", "lovense-dongle-manager", "lovense-connect-service-manager", "websocket-server-manager", "usb-manager"]
 client=[]
 server=[]
 serialize-json=[]
@@ -26,6 +26,7 @@ serial-manager=["server", "serialport"]
 lovense-dongle-manager=["server", "serialport", "hidapi"]
 lovense-connect-service-manager=["server","reqwest"]
 websocket-server-manager=["server", "websockets"]
+usb-manager=["rusb"]
 # Runtime managers
 tokio-runtime=["tokio/rt-multi-thread", "async-tungstenite/tokio-runtime", "async-tungstenite/tokio-native-tls"]
 wasm-bindgen-runtime=["wasm-bindgen", "wasm-bindgen-futures"]
@@ -79,6 +80,7 @@ os_info = "3.5.1"
 jsonschema = { version = "0.16.1", default-features = false, features = ["resolve-file"] }
 derivative = "2.2.0"
 tokio-stream = "0.1.11"
+rusb = { version = "0.9.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 rusty-xinput = "1.2.0"

--- a/buttplug/src/server/device/configuration/specifier.rs
+++ b/buttplug/src/server/device/configuration/specifier.rs
@@ -391,4 +391,5 @@ impl PartialEq for ProtocolCommunicationSpecifier {
   }
 }
 
-impl Eq for ProtocolCommunicationSpecifier {}
+impl Eq for ProtocolCommunicationSpecifier {
+}

--- a/buttplug/src/server/device/configuration/specifier.rs
+++ b/buttplug/src/server/device/configuration/specifier.rs
@@ -315,6 +315,15 @@ pub struct USBSpecifier {
   product_id: u16,
 }
 
+impl USBSpecifier {
+  pub fn new_from_ids(vendor_id: u16, product_id: u16) -> Self {
+    Self {
+      vendor_id,
+      product_id,
+    }
+  }
+}
+
 /// Specifier for Websocket Device Manager devices
 ///
 /// The websocket device manager is a network based manager, so we have no info other than possibly
@@ -382,5 +391,4 @@ impl PartialEq for ProtocolCommunicationSpecifier {
   }
 }
 
-impl Eq for ProtocolCommunicationSpecifier {
-}
+impl Eq for ProtocolCommunicationSpecifier {}

--- a/buttplug/src/server/device/hardware/communication/mod.rs
+++ b/buttplug/src/server/device/hardware/communication/mod.rs
@@ -13,6 +13,8 @@ pub mod lovense_connect_service;
 pub mod lovense_dongle;
 #[cfg(feature = "serial-manager")]
 pub mod serialport;
+#[cfg(feature = "usb-manager")]
+pub mod usb;
 #[cfg(feature = "websocket-server-manager")]
 pub mod websocket_server;
 #[cfg(all(feature = "xinput-manager", target_os = "windows"))]
@@ -74,6 +76,9 @@ pub enum HardwareSpecificError {
   #[cfg(feature = "serial-manager")]
   #[error("Serial error: {0}")]
   SerialError(String),
+  #[cfg(feature = "usb-manager")]
+  #[error("USB error: {0}")]
+  UsbError(String),
 }
 
 #[async_trait]

--- a/buttplug/src/server/device/hardware/communication/usb/mod.rs
+++ b/buttplug/src/server/device/hardware/communication/usb/mod.rs
@@ -1,0 +1,8 @@
+mod usb_comm_manager;
+mod usb_hardware;
+
+pub use usb_comm_manager::{
+  UsbCommunicationManager,
+  UsbCommunicationManagerBuilder,
+};
+pub use usb_hardware::{UsbHardware, UsbHardwareConnector};

--- a/buttplug/src/server/device/hardware/communication/usb/mod.rs
+++ b/buttplug/src/server/device/hardware/communication/usb/mod.rs
@@ -1,8 +1,5 @@
 mod usb_comm_manager;
 mod usb_hardware;
 
-pub use usb_comm_manager::{
-  UsbCommunicationManager,
-  UsbCommunicationManagerBuilder,
-};
+pub use usb_comm_manager::{UsbCommunicationManager, UsbCommunicationManagerBuilder};
 pub use usb_hardware::{UsbHardware, UsbHardwareConnector};

--- a/buttplug/src/server/device/hardware/communication/usb/usb_comm_manager.rs
+++ b/buttplug/src/server/device/hardware/communication/usb/usb_comm_manager.rs
@@ -1,0 +1,179 @@
+use super::usb_hardware::{DeviceExt, UsbHardwareConnector};
+use crate::{
+  core::errors::ButtplugDeviceError,
+  core::ButtplugResultFuture,
+  server::device::hardware::communication::{
+    HardwareCommunicationManager,
+    HardwareCommunicationManagerBuilder,
+    HardwareCommunicationManagerEvent,
+    HardwareSpecificError,
+  },
+  util::async_manager,
+};
+use async_trait::async_trait;
+use futures_util::FutureExt;
+use rusb::{self, UsbContext};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::sync::{broadcast, mpsc};
+
+#[derive(Default, Clone)]
+pub struct UsbCommunicationManagerBuilder {}
+
+impl HardwareCommunicationManagerBuilder for UsbCommunicationManagerBuilder {
+  fn finish(
+    &mut self,
+    sender: mpsc::Sender<HardwareCommunicationManagerEvent>,
+  ) -> Box<dyn HardwareCommunicationManager> {
+    Box::new(UsbCommunicationManager::new(sender))
+  }
+}
+
+pub struct UsbCommunicationManager {
+  sender: mpsc::Sender<HardwareCommunicationManagerEvent>,
+  context: rusb::Context,
+  scanning_status: Arc<AtomicBool>,
+  hotplug_registration: Arc<Mutex<Option<rusb::Registration<rusb::Context>>>>,
+}
+
+impl UsbCommunicationManager {
+  fn new(sender: mpsc::Sender<HardwareCommunicationManagerEvent>) -> Self {
+    assert!(
+      rusb::has_hotplug(),
+      "USB manager requires libusb hotplug support"
+    );
+    Self {
+      sender,
+      context: rusb::Context::new().expect("USB manager couldn't create libusb context."),
+      scanning_status: Arc::new(AtomicBool::new(false)),
+      hotplug_registration: Arc::new(Mutex::new(None)),
+    }
+  }
+}
+
+#[async_trait]
+impl HardwareCommunicationManager for UsbCommunicationManager {
+  fn name(&self) -> &'static str {
+    "UsbCommunicationManager"
+  }
+
+  fn start_scanning(&mut self) -> ButtplugResultFuture {
+    trace!("USB manager starting scan");
+    self.scanning_status.store(true, Ordering::SeqCst);
+    let context = self.context.clone();
+    let scanning_status = self.scanning_status.clone();
+    let comm_sender = self.sender.clone();
+    let hotplug_registration = self.hotplug_registration.clone();
+    async move {
+      trace!("USB manager registering hotplugger");
+      let (hotplug_sender, hotplug_receiver) = broadcast::channel(256);
+      let hotplugger = UsbHotplugger {
+        sender: hotplug_sender,
+      };
+      async_manager::spawn(handle_usb_context_events(context.clone(), scanning_status));
+      async_manager::spawn(handle_usb_hotplug_events(hotplug_receiver, comm_sender));
+      let registration = rusb::HotplugBuilder::new()
+        .enumerate(true)
+        .register(context, Box::new(hotplugger))
+        .map_err(|e: rusb::Error| {
+          ButtplugDeviceError::from(HardwareSpecificError::UsbError(format!(
+            "USB manager couldn't register hotplugger: {e:?}"
+          )))
+        })?;
+      let mut lock = hotplug_registration.lock().await;
+      *lock = Some(registration);
+      Ok(())
+    }
+    .boxed()
+  }
+
+  fn stop_scanning(&mut self) -> ButtplugResultFuture {
+    trace!("USB manager stopping scan");
+    self.scanning_status.store(false, Ordering::SeqCst);
+    let hotplug_registration = self.hotplug_registration.clone();
+    async move {
+      trace!("USB manager de-registering hotplugger");
+      let mut lock = hotplug_registration.lock().await;
+      *lock = None;
+      Ok(())
+    }
+    .boxed()
+  }
+
+  fn can_scan(&self) -> bool {
+    self.scanning_status.load(Ordering::SeqCst)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub enum UsbHotplugEvent {
+  Arrived(rusb::Device<rusb::Context>),
+  Left(rusb::Device<rusb::Context>),
+}
+
+/// Thread that handles libusb context events during scan.
+async fn handle_usb_context_events(context: rusb::Context, scanning_status: Arc<AtomicBool>) {
+  loop {
+    if !scanning_status.load(Ordering::SeqCst) {
+      debug!("USB manager ended scan");
+      return;
+    }
+    if let Err(e) = context.handle_events(Some(Duration::from_millis(500))) {
+      error!("libusb context handle_events failed: {e:?}");
+      return;
+    }
+  }
+}
+
+/// Thread that handles device arrived events from hotplugger during scan.
+async fn handle_usb_hotplug_events(
+  mut hotplug_receiver: broadcast::Receiver<UsbHotplugEvent>,
+  comm_sender: mpsc::Sender<HardwareCommunicationManagerEvent>,
+) {
+  while let Ok(event) = hotplug_receiver.recv().await {
+    if let UsbHotplugEvent::Arrived(device) = event {
+      let name = device.name();
+      let address = device.qualified_address();
+      debug!("USB manager found device {name}, {address}");
+      let creator = Box::new(UsbHardwareConnector::new(
+        device,
+        hotplug_receiver.resubscribe(),
+      ));
+      let event = HardwareCommunicationManagerEvent::DeviceFound {
+        name,
+        address,
+        creator,
+      };
+      if let Err(e) = comm_sender.send(event).await {
+        error!("Error sending device found message from USB manager: {e:?}");
+      }
+    }
+  }
+  debug!("USB hotplugger closing down");
+}
+
+/// Registered with an `rusb::Context` to handle hotplug events.
+struct UsbHotplugger {
+  sender: broadcast::Sender<UsbHotplugEvent>,
+}
+
+impl rusb::Hotplug<rusb::Context> for UsbHotplugger {
+  fn device_arrived(&mut self, device: rusb::Device<rusb::Context>) {
+    debug!(
+      "USB hotplugger device arrived: {}",
+      device.qualified_address()
+    );
+    if let Err(e) = self.sender.send(UsbHotplugEvent::Arrived(device)) {
+      error!("USB hotplugger couldn't send device arrived hotplug event: {e:?}");
+    }
+  }
+
+  fn device_left(&mut self, device: rusb::Device<rusb::Context>) {
+    debug!("USB hotplugger device left: {}", device.qualified_address());
+    if let Err(e) = self.sender.send(UsbHotplugEvent::Left(device)) {
+      error!("USB hotplugger couldn't send device left hotplug event: {e:?}");
+    }
+  }
+}

--- a/buttplug/src/server/device/hardware/communication/usb/usb_hardware.rs
+++ b/buttplug/src/server/device/hardware/communication/usb/usb_hardware.rs
@@ -1,0 +1,256 @@
+use super::usb_comm_manager::UsbHotplugEvent;
+use crate::{
+  core::{errors::ButtplugDeviceError, message::Endpoint},
+  server::device::hardware::communication::HardwareSpecificError,
+  server::device::{
+    configuration::{ProtocolCommunicationSpecifier, USBSpecifier},
+    hardware::{
+      GenericHardwareSpecializer,
+      Hardware,
+      HardwareConnector,
+      HardwareEvent,
+      HardwareInternal,
+      HardwareReadCmd,
+      HardwareReading,
+      HardwareSpecializer,
+      HardwareSubscribeCmd,
+      HardwareUnsubscribeCmd,
+      HardwareWriteCmd,
+    },
+  },
+  util::async_manager,
+};
+use async_trait::async_trait;
+use futures::future::{self, BoxFuture, FutureExt};
+use rusb;
+use std::sync::Arc;
+use std::{fmt::Debug, time::Duration};
+use tokio::sync::{broadcast, Mutex};
+
+pub trait DeviceExt {
+  /// String for device bus and address on that bus.
+  fn qualified_address(&self) -> String;
+
+  /// Open device and read strings to build a display name.
+  /// Never fails but may return a placeholder.
+  fn name(&self) -> String;
+}
+
+impl<T: rusb::UsbContext> DeviceExt for rusb::Device<T> {
+  fn qualified_address(&self) -> String {
+    let bus_number = self.bus_number();
+    let bus_address = self.address();
+    format!("bus {bus_number}, address {bus_address}")
+  }
+
+  fn name(&self) -> String {
+    let unknown = "???".to_string();
+    let mut manufacturer = unknown.clone();
+    let mut product = unknown.clone();
+    let mut serial_number: Option<String> = None;
+    if let Ok(handle) = self.open() {
+      if let Ok(device_descriptor) = self.device_descriptor() {
+        if let Ok(string) = handle.read_manufacturer_string_ascii(&device_descriptor) {
+          manufacturer = string.trim().into();
+        }
+        if let Ok(string) = handle.read_product_string_ascii(&device_descriptor) {
+          product = string.trim().into();
+        }
+        // Many devices don't have a serial number, so this will often be empty.
+        if let Ok(string) = handle.read_serial_number_string_ascii(&device_descriptor) {
+          serial_number = Some(string.trim().into());
+        }
+      };
+    };
+    if let Some(serial_number) = serial_number {
+      format!("{manufacturer} {product} {serial_number}")
+    } else {
+      format!("{manufacturer} {product}")
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct UsbHardwareConnector {
+  device: rusb::Device<rusb::Context>,
+  hotplug_receiver: Option<broadcast::Receiver<UsbHotplugEvent>>,
+}
+
+impl UsbHardwareConnector {
+  pub fn new(
+    device: rusb::Device<rusb::Context>,
+    hotplug_receiver: broadcast::Receiver<UsbHotplugEvent>,
+  ) -> Self {
+    Self {
+      device,
+      hotplug_receiver: Some(hotplug_receiver),
+    }
+  }
+}
+
+#[async_trait]
+impl HardwareConnector for UsbHardwareConnector {
+  fn specifier(&self) -> ProtocolCommunicationSpecifier {
+    let device_descriptor = self
+      .device
+      .device_descriptor()
+      .expect("USB connector couldn't get device descriptor");
+    ProtocolCommunicationSpecifier::USB(USBSpecifier::new_from_ids(
+      device_descriptor.vendor_id(),
+      device_descriptor.product_id(),
+    ))
+  }
+
+  async fn connect(&mut self) -> Result<Box<dyn HardwareSpecializer>, ButtplugDeviceError> {
+    let name = self.device.name();
+    let address = self.device.qualified_address();
+    debug!("USB connector emitting a new USB device impl: {name}, {address}");
+    if let Some(hotplug_receiver) = self.hotplug_receiver.take() {
+      let hardware_internal = UsbHardware::try_create(self.device.clone(), hotplug_receiver)?;
+      let hardware = Hardware::new(
+        &name,
+        &address,
+        &[Endpoint::TxVendorControl],
+        Box::new(hardware_internal),
+      );
+      Ok(Box::new(GenericHardwareSpecializer::new(hardware)))
+    } else {
+      Err(ButtplugDeviceError::DeviceConnectionError(
+        "USB hardware connectors can't be reused".to_owned(),
+      ))
+    }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct UsbHardware {
+  handle: Arc<Mutex<rusb::DeviceHandle<rusb::Context>>>,
+  address: String,
+  event_sender: broadcast::Sender<HardwareEvent>,
+}
+
+impl UsbHardware {
+  pub fn try_create(
+    device: rusb::Device<rusb::Context>,
+    hotplug_receiver: broadcast::Receiver<UsbHotplugEvent>,
+  ) -> Result<Self, ButtplugDeviceError> {
+    let handle = device.open().map_err(|e: rusb::Error| {
+      ButtplugDeviceError::from(HardwareSpecificError::UsbError(format!("{:?}", e)))
+    })?;
+    let (device_event_sender, _) = broadcast::channel(256);
+    let address = device.qualified_address();
+    async_manager::spawn(handle_usb_hotplug_events(
+      hotplug_receiver,
+      device_event_sender.clone(),
+      address.clone(),
+    ));
+    Ok(Self {
+      handle: Arc::new(Mutex::new(handle)),
+      address,
+      event_sender: device_event_sender,
+    })
+  }
+}
+
+/// This is based on the Buttplug C# code for driving the Rez Trance Vibrator,
+/// the only supported non-HID USB device in that previous version of Buttplug,
+/// and will need to be extended to support with any other USB device.
+/// See <https://github.com/buttplugio/buttplug-csharp/blob/master/Buttplug.Server.Managers.WinUSBManager/WinUSBDeviceImpl.cs>.
+impl HardwareInternal for UsbHardware {
+  /// We shouldn't have to do anything, assuming the `UsbHardware` gets dropped sometime after this,
+  /// which should close the `rusb::DeviceHandle` and its underlying libusb handle.
+  fn disconnect(&self) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Ok(())).boxed()
+  }
+
+  fn event_stream(&self) -> broadcast::Receiver<HardwareEvent> {
+    self.event_sender.subscribe()
+  }
+
+  fn read_value(
+    &self,
+    _msg: &HardwareReadCmd,
+  ) -> BoxFuture<'static, Result<HardwareReading, ButtplugDeviceError>> {
+    future::ready(Err(ButtplugDeviceError::UnhandledCommand(
+      "USB hardware does not support read_value".to_owned(),
+    )))
+    .boxed()
+  }
+
+  fn write_value(
+    &self,
+    msg: &HardwareWriteCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    if msg.endpoint != Endpoint::TxVendorControl {
+      return future::ready(Err(ButtplugDeviceError::InvalidEndpoint(msg.endpoint))).boxed();
+    }
+
+    let handle = self.handle.clone();
+    let data = msg.data.clone();
+    let address = self.address.clone();
+    let event_sender = self.event_sender.clone();
+    async move {
+      let lock = handle.lock().await;
+      let result = lock.write_control(
+        rusb::request_type(
+          rusb::Direction::Out,
+          rusb::RequestType::Vendor,
+          rusb::Recipient::Interface,
+        ),
+        1,
+        data[0] as u16,
+        0,
+        &[],
+        Duration::from_millis(100),
+      );
+      if result == Err(rusb::Error::NoDevice) {
+        if let Err(e) = event_sender.send(HardwareEvent::Disconnected(address)) {
+          error!("USB hardware failed to send disconnected event: {e:?}");
+        }
+      }
+      result.map_err(|e: rusb::Error| {
+        ButtplugDeviceError::from(HardwareSpecificError::UsbError(format!("{e:?}")))
+      })?;
+      Ok(())
+    }
+    .boxed()
+  }
+
+  fn subscribe(
+    &self,
+    _msg: &HardwareSubscribeCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Err(ButtplugDeviceError::UnhandledCommand(
+      "USB hardware does not support subscribe".to_owned(),
+    )))
+    .boxed()
+  }
+
+  fn unsubscribe(
+    &self,
+    _msg: &HardwareUnsubscribeCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Err(ButtplugDeviceError::UnhandledCommand(
+      "USB hardware does not support unsubscribe".to_owned(),
+    )))
+    .boxed()
+  }
+}
+
+/// Handle any disconnection events relevant to this device during scan.
+async fn handle_usb_hotplug_events(
+  mut hotplug_receiver: broadcast::Receiver<UsbHotplugEvent>,
+  event_sender: broadcast::Sender<HardwareEvent>,
+  address: String,
+) {
+  while let Ok(event) = hotplug_receiver.recv().await {
+    if let UsbHotplugEvent::Left(device) = event {
+      if device.qualified_address() == address {
+        if let Err(e) = event_sender.send(HardwareEvent::Disconnected(address.clone())) {
+          error!("USB hardware hotplug handler failed to send disconnected event: {e:?}");
+        }
+      }
+    }
+  }
+  debug!("USB hardware hotplug handler for {address} closing down");
+}

--- a/buttplug/src/server/device/protocol/mod.rs
+++ b/buttplug/src/server/device/protocol/mod.rs
@@ -56,6 +56,7 @@ pub mod pink_punch;
 pub mod prettylove;
 pub mod raw_protocol;
 pub mod realov;
+pub mod rez_trance_vibrator;
 pub mod sakuraneko;
 pub mod satisfyer;
 pub mod svakom;
@@ -80,14 +81,8 @@ use crate::{
   core::{
     errors::ButtplugDeviceError,
     message::{
-      self,
-      ActuatorType,
-      ButtplugDeviceCommandMessageUnion,
-      ButtplugDeviceMessage,
-      ButtplugServerDeviceMessage,
-      ButtplugServerMessage,
-      Endpoint,
-      SensorType,
+      self, ActuatorType, ButtplugDeviceCommandMessageUnion, ButtplugDeviceMessage,
+      ButtplugServerDeviceMessage, ButtplugServerMessage, Endpoint, SensorType,
     },
   },
   server::device::{
@@ -321,6 +316,10 @@ pub fn get_default_protocol_map() -> HashMap<String, Arc<dyn ProtocolIdentifierF
   add_to_protocol_map(
     &mut map,
     kgoal_boost::setup::KGoalBoostIdentifierFactory::default(),
+  );
+  add_to_protocol_map(
+    &mut map,
+    rez_trance_vibrator::setup::RezTranceVibratorIdentifierFactory::default(),
   );
   map
 }

--- a/buttplug/src/server/device/protocol/mod.rs
+++ b/buttplug/src/server/device/protocol/mod.rs
@@ -81,8 +81,14 @@ use crate::{
   core::{
     errors::ButtplugDeviceError,
     message::{
-      self, ActuatorType, ButtplugDeviceCommandMessageUnion, ButtplugDeviceMessage,
-      ButtplugServerDeviceMessage, ButtplugServerMessage, Endpoint, SensorType,
+      self,
+      ActuatorType,
+      ButtplugDeviceCommandMessageUnion,
+      ButtplugDeviceMessage,
+      ButtplugServerDeviceMessage,
+      ButtplugServerMessage,
+      Endpoint,
+      SensorType,
     },
   },
   server::device::{

--- a/buttplug/src/server/device/protocol/rez_trance_vibrator.rs
+++ b/buttplug/src/server/device/protocol/rez_trance_vibrator.rs
@@ -1,0 +1,26 @@
+use crate::core::errors::ButtplugDeviceError;
+use crate::core::message::Endpoint;
+use crate::server::device::hardware::{HardwareCommand, HardwareWriteCmd};
+use crate::server::device::protocol::{generic_protocol_setup, ProtocolHandler};
+
+generic_protocol_setup!(RezTranceVibrator, "rez-trancevibrator");
+
+#[derive(Default)]
+pub struct RezTranceVibrator {}
+
+impl ProtocolHandler for RezTranceVibrator {
+  fn handle_scalar_vibrate_cmd(
+    &self,
+    _index: u32,
+    scalar: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    let r_speed = scalar as u8;
+    let data = vec![r_speed];
+    Ok(vec![HardwareWriteCmd::new(
+      Endpoint::TxVendorControl,
+      data,
+      false,
+    )
+    .into()])
+  }
+}

--- a/buttplug/src/util/mod.rs
+++ b/buttplug/src/util/mod.rs
@@ -96,6 +96,11 @@ pub async fn in_process_client(client_name: &str, allow_raw_messages: bool) -> B
     use crate::server::device::hardware::communication::xinput::XInputDeviceCommunicationManagerBuilder;
     server_builder.comm_manager(XInputDeviceCommunicationManagerBuilder::default());
   }
+  #[cfg(feature = "usb-manager")]
+  {
+    use crate::server::device::hardware::communication::usb::UsbCommunicationManagerBuilder;
+    server_builder.comm_manager(UsbCommunicationManagerBuilder::default());
+  }
   if allow_raw_messages {
     server_builder.allow_raw_messages();
   }


### PR DESCRIPTION
I know this is an antique device, but previous versions of buttplug supported it and I have one to test with, so I thought I'd bring it back.

Works under (at least) macOS Ventura and Linux Mint 20.

As [previously described](https://youtu.be/rAYdo1vDNak?t=321) and discussed in Discord a few days ago, doesn't work under Windows 10 on actual hardware due to the USB descriptor issue, although I hold out some hope that [it might be possible at some point for Win10 virtualized under a non-Windows host](https://demon.social/@vyr/109356585941413613).

I have not yet tested on WASM with WebUSB; although this is supposed to be something that libusb supports, I'm not familiar enough with WASM runtime environments or buttplug to know where to start.