### PR TITLE
Implemented a deserializer for the battery field.

### DIFF
--- a/buttplug/src/server/device/protocol/lovense_connect_service.rs
+++ b/buttplug/src/server/device/protocol/lovense_connect_service.rs
@@ -96,7 +96,7 @@ impl ProtocolHandler for LovenseConnectService {
       if vibrate_cmds.len() == 1 || vibrate_cmds.windows(2).all(|w| w[0] == w[1]) {
         let lovense_cmd = format!(
           "Vibrate?v={}&t={}",
-          cmds[0].expect("Already checked existence").1,
+          vibrate_cmds[0].1,
           self.address
         )
         .as_bytes()


### PR DESCRIPTION
The battery field needs to be able to handle when the JSON field for it is null.

Because when a toy connects, Lovense Connect will send null in the battery field until the toy has been fully initialized I'm guessing?
In my opinion Lovense Connect should just send 0 instead of sending null when a toy isn't fully initialized.

The bug behaviour is:
1. Connect a ButtplugClient
2. Start Lovense connect
3. Connect toy to Lovense Connect
4. Call ButtplugClient::start_scanning()
5. The JSON deserialization will fail and will not parse the incoming connected toy.
6. Scan again and you will get the battery number.