### PR TITLE
Kiiroo Pearl 2.1 sensors and battery level

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -2372,6 +2372,64 @@
                 ],
                 "ActuatorType": "Vibrate"
               }
+            ],
+            "SensorReadCmd": [
+              {
+                "SensorType": "Battery",
+                "FeatureDescriptor": "Battery Level",
+                "SensorRange": [
+                  [
+                    0,
+                    100
+                  ]
+                ]
+              }
+            ],
+            "SensorSubscribeCmd": [
+              {
+                "SensorType": "Pressure",
+                "FeatureDescriptor": "Pressure (analog)",
+                "SensorRange": [
+                  [
+                    0,
+                    65535
+                  ],
+                  [
+                    0,
+                    65535
+                  ],
+                  [
+                    0,
+                    65535
+                  ],
+                  [
+                    0,
+                    65535
+                  ]
+                ]
+              },
+              {
+                "SensorType": "Button",
+                "FeatureDescriptor": "Pressure (digital)",
+                "SensorRange": [
+                  [
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    1
+                  ]
+                ]
+              }
             ]
           }
         },

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -1251,7 +1251,7 @@ protocols:
         - Pulse Interactive
       services:
         00001900-0000-1000-8000-00805f9b34fb:
-          # Used to clear the whitelist
+          # Used to clear the whitelist and read battery level
           whitelist: 00001901-0000-1000-8000-00805f9b34fb
           tx: 00001902-0000-1000-8000-00805f9b34fb
           rx: 00001903-0000-1000-8000-00805f9b34fb
@@ -1269,6 +1269,17 @@ protocols:
           ScalarCmd:
             - StepRange: [0, 100]
               ActuatorType: Vibrate
+          SensorReadCmd:
+            - SensorType: Battery
+              FeatureDescriptor: Battery Level
+              SensorRange: [[0, 100]]
+          SensorSubscribeCmd:
+            - SensorType: Pressure
+              FeatureDescriptor: Pressure (analog)
+              SensorRange: [[0, 65535], [0, 65535], [0, 65535], [0, 65535]]
+            - SensorType: Button
+              FeatureDescriptor: Pressure (digital)
+              SensorRange: [[0, 1], [0, 1], [0, 1], [0, 1]]
       - identifier:
           - Cliona
         name: Kiiroo Cliona

--- a/buttplug/src/server/device/protocol/kiiroo_v21.rs
+++ b/buttplug/src/server/device/protocol/kiiroo_v21.rs
@@ -9,23 +9,65 @@ use super::fleshlight_launch_helper::calculate_speed;
 use crate::{
   core::{
     errors::ButtplugDeviceError,
-    message::{self, ButtplugDeviceMessage, Endpoint},
+    message::{
+      self,
+      ButtplugDeviceMessage,
+      ButtplugMessage,
+      ButtplugServerDeviceMessage,
+      ButtplugServerMessage,
+      Endpoint,
+      SensorReading,
+      SensorType,
+    },
   },
   server::device::{
-    hardware::{HardwareCommand, HardwareWriteCmd},
+    hardware::{
+      Hardware,
+      HardwareCommand,
+      HardwareEvent,
+      HardwareReadCmd,
+      HardwareSubscribeCmd,
+      HardwareUnsubscribeCmd,
+      HardwareWriteCmd,
+    },
     protocol::{generic_protocol_setup, ProtocolHandler},
   },
+  util::{async_manager, stream::convert_broadcast_receiver_to_stream},
 };
-use std::sync::{
-  atomic::{AtomicU8, Ordering::SeqCst},
-  Arc,
+use dashmap::DashSet;
+use futures::{
+  future::{self, BoxFuture},
+  FutureExt,
+  StreamExt,
 };
+use std::{
+  default::Default,
+  pin::Pin,
+  sync::{
+    atomic::{AtomicU8, Ordering::SeqCst},
+    Arc,
+  },
+};
+use tokio::sync::broadcast;
 
 generic_protocol_setup!(KiirooV21, "kiiroo-v21");
 
-#[derive(Default)]
 pub struct KiirooV21 {
   previous_position: Arc<AtomicU8>,
+  // Set of sensors we've subscribed to for updates.
+  subscribed_sensors: Arc<DashSet<u32>>,
+  event_stream: broadcast::Sender<ButtplugServerDeviceMessage>,
+}
+
+impl Default for KiirooV21 {
+  fn default() -> Self {
+    let (sender, _) = broadcast::channel(256);
+    Self {
+      previous_position: Default::default(),
+      subscribed_sensors: Arc::new(DashSet::new()),
+      event_stream: sender,
+    }
+  }
 }
 
 impl ProtocolHandler for KiirooV21 {
@@ -72,6 +114,152 @@ impl ProtocolHandler for KiirooV21 {
       false,
     )
     .into()])
+  }
+
+  fn handle_battery_level_cmd(
+    &self,
+    device: Arc<Hardware>,
+    message: message::SensorReadCmd,
+  ) -> BoxFuture<Result<ButtplugServerMessage, ButtplugDeviceError>> {
+    debug!("Trying to get battery reading.");
+    // Reading the "whitelist" endpoint for this device retrieves the battery level,
+    // which is byte 5. All other bytes of the 20-byte result are unknown.
+    let msg = HardwareReadCmd::new(Endpoint::Whitelist, 20, 0);
+    let fut = device.read_value(&msg);
+    async move {
+      let hw_msg = fut.await?;
+      let data = hw_msg.data();
+      if data.len() != 20 {
+        // Maybe not the Kiiroo Pearl 2.1?
+        return Err(ButtplugDeviceError::DeviceCommunicationError(
+          "Kiiroo battery data not expected length!".to_owned(),
+        ));
+      }
+      let battery_level = data[5] as i32;
+      let battery_reading = message::SensorReading::new(
+        message.device_index(),
+        *message.sensor_index(),
+        *message.sensor_type(),
+        vec![battery_level],
+      );
+      debug!("Got battery reading: {}", battery_level);
+      Ok(battery_reading.into())
+    }
+    .boxed()
+  }
+
+  fn event_stream(
+    &self,
+  ) -> Pin<Box<dyn futures::Stream<Item = ButtplugServerDeviceMessage> + Send>> {
+    convert_broadcast_receiver_to_stream(self.event_stream.subscribe()).boxed()
+  }
+
+  fn handle_sensor_subscribe_cmd(
+    &self,
+    device: Arc<Hardware>,
+    message: message::SensorSubscribeCmd,
+  ) -> BoxFuture<Result<ButtplugServerMessage, ButtplugDeviceError>> {
+    if self.subscribed_sensors.contains(message.sensor_index()) {
+      return future::ready(Ok(message::Ok::new(message.id()).into())).boxed();
+    }
+    let sensors = self.subscribed_sensors.clone();
+    // Format for the Kiiroo Pearl 2.1:
+    // Byte 0-1: Raw u16be pressure sensor, smaller values indicate more pressure, channel 1.
+    //           Zero values differ even between sensors on same device.
+    //           Legal range is not known (might even be i16le),
+    //           actual range on one device is around 850±50.
+    // Byte 2-3: Same, channel 2.
+    // Byte 4-5: Same, channel 3.
+    // Byte 6-7: Same, channel 4.
+    // Byte 8: Flags corresponding to pressure regions, thresholded on device:
+    //         LSB is channel 1 pressed, next least significant bit is channel 2, etc.
+    async move {
+      // If we have no sensors we're currently subscribed to, we'll need to bring up our BLE
+      // characteristic subscription.
+      if sensors.is_empty() {
+        device
+          .subscribe(&HardwareSubscribeCmd::new(Endpoint::Rx))
+          .await?;
+        let sender = self.event_stream.clone();
+        let mut hardware_stream = device.event_stream();
+        let stream_sensors = sensors.clone();
+        let device_index = message.device_index();
+        // If we subscribe successfully, we need to set up our event handler.
+        async_manager::spawn(async move {
+          while let Ok(info) = hardware_stream.recv().await {
+            // If we have no receivers, quit.
+            if sender.receiver_count() == 0 || stream_sensors.is_empty() {
+              return;
+            }
+            if let HardwareEvent::Notification(_, endpoint, data) = info {
+              if endpoint == Endpoint::Rx {
+                if data.len() != 9 {
+                  // Maybe not the Kiiroo Pearl 2.1?
+                  error!("Kiiroo sensor data not expected length!");
+                  continue;
+                }
+                // Extract our pressure values.
+                // Invert analog values so that the value increases with pressure.
+                let analog: Vec<i32> = (0..4)
+                  .into_iter()
+                  .map(|i| {
+                    (u16::MAX as i32) - ((data[2 * i] as i32) << 8 | (data[2 * i + 1] as i32))
+                  })
+                  .collect();
+                let digital: Vec<i32> = (0..4)
+                  .into_iter()
+                  .map(|i| ((data[8] as i32) >> i) & 1)
+                  .collect();
+                for ((sensor_index, sensor_type), sensor_data) in (0u32..)
+                  .zip([SensorType::Pressure, SensorType::Button])
+                  .zip([analog, digital])
+                {
+                  if stream_sensors.contains(&sensor_index)
+                    && sender
+                      .send(
+                        SensorReading::new(device_index, sensor_index, sensor_type, sensor_data)
+                          .into(),
+                      )
+                      .is_err()
+                  {
+                    debug!(
+                    "Hardware device listener for Kiiroo 2.1 device shut down, returning from task."
+                  );
+                    return;
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+      sensors.insert(*message.sensor_index());
+      Ok(message::Ok::new(message.id()).into())
+    }
+    .boxed()
+  }
+
+  fn handle_sensor_unsubscribe_cmd(
+    &self,
+    device: Arc<Hardware>,
+    message: message::SensorUnsubscribeCmd,
+  ) -> BoxFuture<Result<ButtplugServerMessage, ButtplugDeviceError>> {
+    if !self.subscribed_sensors.contains(message.sensor_index()) {
+      return future::ready(Ok(message::Ok::new(message.id()).into())).boxed();
+    }
+    let sensors = self.subscribed_sensors.clone();
+    async move {
+      // If we have no sensors we're currently subscribed to, we'll need to end our BLE
+      // characteristic subscription.
+      sensors.remove(message.sensor_index());
+      if sensors.is_empty() {
+        device
+          .unsubscribe(&HardwareUnsubscribeCmd::new(Endpoint::Rx))
+          .await?;
+      }
+      Ok(message::Ok::new(message.id()).into())
+    }
+    .boxed()
   }
 }
 


### PR DESCRIPTION
Found the pressure sensors and battery level by inspecting and visualizing received BTLE data.

<img width="1544" alt="Sketchy graph showing a correlation between analog and digital versions of pressure sensor data" src="https://user-images.githubusercontent.com/26195552/205473333-1250370a-7367-4851-8a8d-96a1712f5e01.png">

The sensor endpoint reports both analog and digital versions of the same data for 4 touch sensors, but the sensors are so flaky that it's hard to tell which end of the device is the start of the sensor array. This is likely only going to be useful for distinguishing between contact and no contact, not as a depth sensor. (I wonder if the Pearl 3 is any better?)

I've been conservative with the possible sensor ranges. It might be possible to put a tighter bound on them if desired, but that will require reversing the FeelConnect app; sensor ranges are slightly different even for different pressure sensor areas on the device, and could well be very different from device to device.

The app doesn't report battery level on iOS anywhere I can find it and doesn't use the standard BTLE battery endpoint. I do know that byte goes down steadily with use, and that the device starts blinking red around 10 and shuts off shortly after reaching 1. I've never seen my device go past a battery byte value of 82, but I suspect that its battery pack is damaged, so the actual max might be 100 or 255.

Since this is only the second sensor-enabled device in the current codebase, I reused code from the KGoal Boost, and still have some open questions:
- Are sensor indexes supposed to be unique within a device, or unique within a device _and_ sensor type?
- Why are sensor ranges `u32` but sensor data `i32`?
- Should battery sensors always be scaled to [0, 100] so that `battery_level` always reports a number between 0 and 1?
- What is the "whitelist" endpoint used for on Kiiroo 2.1 devices? I didn't see any obviously device-whitelist-related code for them.
- Is it worth trying to factor out common code for the Kiiroo 2.1 and KGoal Boost sensor implementation now, or should we wait for more sensor-enabled devices?
