### PR TITLE
fix: Do not abort in pipe_connector when UnixStream is not ready yet

### DIFF
--- a/buttplug/src/core/connector/transport/pipe/pipe_client.rs
+++ b/buttplug/src/core/connector/transport/pipe/pipe_client.rs
@@ -10,10 +10,12 @@
 use crate::core::{
   connector::{
     transport::{
-      ButtplugConnectorTransport, ButtplugConnectorTransportSpecificError,
+      ButtplugConnectorTransport,
+      ButtplugConnectorTransportSpecificError,
       ButtplugTransportIncomingMessage,
     },
-    ButtplugConnectorError, ButtplugConnectorResultFuture,
+    ButtplugConnectorError,
+    ButtplugConnectorResultFuture,
   },
   message::serializer::ButtplugSerializedMessage,
 };

--- a/buttplug/src/core/connector/transport/pipe/pipe_client.rs
+++ b/buttplug/src/core/connector/transport/pipe/pipe_client.rs
@@ -10,17 +10,15 @@
 use crate::core::{
   connector::{
     transport::{
-      ButtplugConnectorTransport,
-      ButtplugConnectorTransportSpecificError,
+      ButtplugConnectorTransport, ButtplugConnectorTransportSpecificError,
       ButtplugTransportIncomingMessage,
     },
-    ButtplugConnectorError,
-    ButtplugConnectorResultFuture,
+    ButtplugConnectorError, ButtplugConnectorResultFuture,
   },
   message::serializer::ButtplugSerializedMessage,
 };
 use futures::future::{BoxFuture, FutureExt};
-use std::sync::Arc;
+use std::{io::ErrorKind, sync::Arc};
 #[cfg(target_os = "windows")]
 use tokio::net::windows::named_pipe;
 #[cfg(not(target_os = "windows"))]
@@ -122,6 +120,9 @@ async fn run_connection_loop(
                     break;
                   }
                 },
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                  continue;
+                }
                 Err(err) => {
                   error!("Error from pipe server, assuming disconnection: {:?}", err);
                   break;

--- a/buttplug/src/core/connector/transport/pipe/pipe_server.rs
+++ b/buttplug/src/core/connector/transport/pipe/pipe_server.rs
@@ -10,10 +10,12 @@
 use crate::core::{
   connector::{
     transport::{
-      ButtplugConnectorTransport, ButtplugConnectorTransportSpecificError,
+      ButtplugConnectorTransport,
+      ButtplugConnectorTransportSpecificError,
       ButtplugTransportIncomingMessage,
     },
-    ButtplugConnectorError, ButtplugConnectorResultFuture,
+    ButtplugConnectorError,
+    ButtplugConnectorResultFuture,
   },
   message::serializer::ButtplugSerializedMessage,
 };

--- a/buttplug/src/core/connector/transport/pipe/pipe_server.rs
+++ b/buttplug/src/core/connector/transport/pipe/pipe_server.rs
@@ -10,17 +10,15 @@
 use crate::core::{
   connector::{
     transport::{
-      ButtplugConnectorTransport,
-      ButtplugConnectorTransportSpecificError,
+      ButtplugConnectorTransport, ButtplugConnectorTransportSpecificError,
       ButtplugTransportIncomingMessage,
     },
-    ButtplugConnectorError,
-    ButtplugConnectorResultFuture,
+    ButtplugConnectorError, ButtplugConnectorResultFuture,
   },
   message::serializer::ButtplugSerializedMessage,
 };
 use futures::future::{BoxFuture, FutureExt};
-use std::sync::Arc;
+use std::{io::ErrorKind, sync::Arc};
 #[cfg(target_os = "windows")]
 use tokio::net::windows::named_pipe;
 #[cfg(not(target_os = "windows"))]
@@ -140,6 +138,9 @@ async fn run_connection_loop(
                   }
 
                 },
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                  continue;
+                }
                 Err(err) => {
                   error!("Error from pipe server, assuming disconnection: {:?}", err);
                   break;


### PR DESCRIPTION
See #537

With this the example now works as expected and does not spin forever.
This seems to be the intended way and not break anything, tho I'm a bit unsettled by the fact that the part where the error arose seems to be pretty foundational, and I have no explanation as to why this went unnoticed for *looks at git blame * ... a year?