### PR TITLE
fix: Extend `StepRange` of Sam Neo suction

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -3698,7 +3698,7 @@
             {
               "StepRange": [
                 0,
-                1
+                5 
               ],
               "ActuatorType": "Vibrate"
             }

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -1888,8 +1888,15 @@ protocols:
         ScalarCmd:
           - StepRange: [0, 10]
             ActuatorType: Vibrate
-          - StepRange: [0, 1]
+          - StepRange: [0, 5]
             ActuatorType: Vibrate
+            # suction pattern enum:
+            # 0: off
+            # 1: short
+            # 2: long short short
+            # 3: long short
+            # 4: long long short short
+            # 5: long long long short short
   svakom-alex:
     btle:
       names:


### PR DESCRIPTION
Extends the `StepRange` of SVAKOM Sam Neo device config to cover all patterns, and adds a description of each pattern.