### PR TITLE
WIP: Better WSDM UX

### DIFF
--- a/buttplug/src/server/device/configuration/specifier.rs
+++ b/buttplug/src/server/device/configuration/specifier.rs
@@ -153,6 +153,37 @@ impl PartialEq for BluetoothLESpecifier {
   }
 }
 
+impl PartialEq<WebsocketSpecifier> for BluetoothLESpecifier {
+  fn eq(&self, other: &WebsocketSpecifier) -> bool {
+    // If names or manufacturer data are found, use those automatically.
+    if self.names.intersection(&other.names).count() > 0 {
+      return true;
+    }
+    // Otherwise, try wildcarded names.
+    for name in &self.names {
+      for other_name in &other.names {
+        let compare_name: &String;
+        let mut wildcard: String;
+        if name.ends_with('*') {
+          wildcard = name.clone();
+          compare_name = other_name;
+        } else if other_name.ends_with('*') {
+          wildcard = other_name.clone();
+          compare_name = name;
+        } else {
+          continue;
+        }
+        // Remove asterisk from the end of the wildcard
+        wildcard.pop();
+        if compare_name.starts_with(&wildcard) {
+          return true;
+        }
+      }
+    }
+    false
+  }
+}
+
 impl BluetoothLESpecifier {
   pub fn new(
     names: HashSet<String>,
@@ -385,6 +416,7 @@ impl PartialEq for ProtocolCommunicationSpecifier {
       (HID(self_spec), HID(other_spec)) => self_spec == other_spec,
       (XInput(self_spec), XInput(other_spec)) => self_spec == other_spec,
       (Websocket(self_spec), Websocket(other_spec)) => self_spec == other_spec,
+      (BluetoothLE(self_spec), Websocket(other_spec)) => self_spec == other_spec,
       (LovenseConnectService(self_spec), LovenseConnectService(other_spec)) => {
         self_spec == other_spec
       }


### PR DESCRIPTION
This PR is tracking the headache of having to update the user-config before a new websocket device can connect.

Right now, this simplistic change lets WS devices declare BTLE identifiers, but there's the potential that this could open things too much. As soon as a webpage can connect a device, it could spam the user-config file with new devices, even if they're not enabled by default (disabling new WS devices on connect is not implemented in this PR yet).

There's a trade-off between UX and security here, and whilst I tend to pick security I'm not sure that's the right choice here. 

The prior conversation on Discord:
```
BlackSphereFollower — 03/01/2024 12:16
@qdot Did the wsdm break? I'm seeing it reject devices because it can't match them to a protocol, but it's not matching any because it's not comparing websocket identifiers against bluetooth identifiers. Or do all websocket protocols have to be explicilty declared?

qdot — 03/01/2024 17:56
@BlackSphereFollower I haven't touched that part of code in forever. It may just be a bug, I never really throughly tested the identifer comparison.
websocket protocols shouldn't need specific declaration, it should just be able to suss things out from the protocol/identifier passed to it.

BlackSphereFollower — 03/01/2024 18:02
Ok, I might need to PR a fix there then. I was testing out the glitch hosted speedometer and couldn't get it to work at all
https://github.com/buttplugio/buttplug/compare/dev...blackspherefollower:buttplug-rs:dev Actually before I do, does this look right?

qdot — 03/01/2024 18:28
I think so.

qdot — 03/01/2024 18:29
Oh, um, ok, thinking back on this, devices did need to be explicitly set up with a protocol in the user config. They couldn't just declare it as part of the handshake. 
That was due to security, otherwise anyone could just pop up on the websocket connector.

BlackSphereFollower — 03/01/2024 18:33
That makes total sense and I had wondered if that was the case.

qdot — 03/01/2024 18:33
That said, that's... not the worst idea as long as we gate it.

BlackSphereFollower — 03/01/2024 18:33
Disabled by default? Could still let something spam the config
A nice toast popup for "let this in or block it" might work too, but the block list could also be spammed...
I don't think there's an easy answer here

qdot — 03/01/2024 18:38
Well feel free to draft PR it or make an issue right now just to keep the idea around, but yeah the more we go over this the more the current restrction sonds like it was warrented.
```