### PR TITLE
chore: Replace use of BE bytes and swap combination with LE bytes

### DIFF
--- a/buttplug/src/server/device/protocol/mizzzee_v3.rs
+++ b/buttplug/src/server/device/protocol/mizzzee_v3.rs
@@ -65,7 +65,7 @@ fn scalar_to_vector(scalar: u32) -> Vec<u8> {
   let scale: f32 = handle_scale(scalar as f32 / 1000.0) * 1023.0;
   let modded_scale: u16 = ((scale as u16) << 6) | 60;
 
-  let bytes = modded_scale.swap_bytes().to_be_bytes();
+  let bytes = modded_scale.to_le_bytes();
 
   let mut data: Vec<u8> = Vec::new();
   data.extend_from_slice(&HEADER);


### PR DESCRIPTION
When I was washing myself, when I was in the toilet, the thought often occurred to me: "Maybe to_be_bytes does not mean 'to_be bytes', but 'to BE bytes' - Big Endian, and there's 'to_le_bytes' method as well?". It turned out to be true.

I finally remembered this while I was in a suitable place - at the computer.
Now this thought will not torment me in the bathroom.