### PR TITLE
fix: Correct identification of early Satisfyer devices

### DIFF
--- a/buttplug/src/server/device/protocol/ankni.rs
+++ b/buttplug/src/server/device/protocol/ankni.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/foreo.rs
+++ b/buttplug/src/server/device/protocol/foreo.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/fredorch.rs
+++ b/buttplug/src/server/device/protocol/fredorch.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/fredorch_rotary.rs
+++ b/buttplug/src/server/device/protocol/fredorch_rotary.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/hgod.rs
+++ b/buttplug/src/server/device/protocol/hgod.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/hismith.rs
+++ b/buttplug/src/server/device/protocol/hismith.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{
@@ -40,6 +41,7 @@ impl ProtocolIdentifier for HismithIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let result = hardware
       .read_value(&HardwareReadCmd::new(Endpoint::RxBLEModel, 128, 500))

--- a/buttplug/src/server/device/protocol/hismith_mini.rs
+++ b/buttplug/src/server/device/protocol/hismith_mini.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,
@@ -43,6 +44,7 @@ impl ProtocolIdentifier for HismithMiniIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let result = hardware
       .read_value(&HardwareReadCmd::new(Endpoint::RxBLEModel, 128, 500))

--- a/buttplug/src/server/device/protocol/joyhub.rs
+++ b/buttplug/src/server/device/protocol/joyhub.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/joyhub_v2.rs
+++ b/buttplug/src/server/device/protocol/joyhub_v2.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/kiiroo_v2.rs
+++ b/buttplug/src/server/device/protocol/kiiroo_v2.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/kiiroo_v21_initialized.rs
+++ b/buttplug/src/server/device/protocol/kiiroo_v21_initialized.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/lelo_harmony.rs
+++ b/buttplug/src/server/device/protocol/lelo_harmony.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/lelof1s.rs
+++ b/buttplug/src/server/device/protocol/lelof1s.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/lelof1sv2.rs
+++ b/buttplug/src/server/device/protocol/lelof1sv2.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/leten.rs
+++ b/buttplug/src/server/device/protocol/leten.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/lioness.rs
+++ b/buttplug/src/server/device/protocol/lioness.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/longlosttouch.rs
+++ b/buttplug/src/server/device/protocol/longlosttouch.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::util::async_manager;
 use crate::{
   core::{errors::ButtplugDeviceError, message, message::Endpoint},

--- a/buttplug/src/server/device/protocol/lovedistance.rs
+++ b/buttplug/src/server/device/protocol/lovedistance.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/lovense.rs
+++ b/buttplug/src/server/device/protocol/lovense.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,
@@ -84,6 +87,7 @@ impl ProtocolIdentifier for LovenseIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let mut event_receiver = hardware.event_stream();
     let mut count = 0;

--- a/buttplug/src/server/device/protocol/lovense_connect_service.rs
+++ b/buttplug/src/server/device/protocol/lovense_connect_service.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/metaxsire_repeat.rs
+++ b/buttplug/src/server/device/protocol/metaxsire_repeat.rs
@@ -7,6 +7,7 @@
 
 use crate::core::message::ActuatorType;
 use crate::core::message::ActuatorType::{Constrict, Rotate, Vibrate};
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/metaxsire_v2.rs
+++ b/buttplug/src/server/device/protocol/metaxsire_v2.rs
@@ -6,7 +6,10 @@
 // for full license information.
 
 use crate::core::message::ActuatorType;
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::server::device::hardware::Hardware;
 use crate::server::device::protocol::ProtocolInitializer;
 use crate::{

--- a/buttplug/src/server/device/protocol/metaxsire_v3.rs
+++ b/buttplug/src/server/device/protocol/metaxsire_v3.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/mizzzee_v3.rs
+++ b/buttplug/src/server/device/protocol/mizzzee_v3.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/mod.rs
+++ b/buttplug/src/server/device/protocol/mod.rs
@@ -580,6 +580,7 @@ pub trait ProtocolIdentifier: Sync + Send {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    specifier: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError>;
 }
 
@@ -611,6 +612,7 @@ impl ProtocolIdentifier for GenericProtocolIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let device_identifier = UserDeviceIdentifier::new(
       hardware.address(),
@@ -935,6 +937,7 @@ macro_rules! generic_protocol_initializer_setup {
         async fn identify(
           &mut self,
           hardware: Arc<Hardware>,
+          _: ProtocolCommunicationSpecifier,
         ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
           Ok((UserDeviceIdentifier::new(hardware.address(), $protocol_identifier, &Some(hardware.name().to_owned())), Box::new([< $protocol_name Initializer >]::default())))
         }

--- a/buttplug/src/server/device/protocol/monsterpub.rs
+++ b/buttplug/src/server/device/protocol/monsterpub.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,
@@ -44,6 +45,7 @@ impl ProtocolIdentifier for MonsterPubIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let read_resp = hardware
       .read_value(&HardwareReadCmd::new(Endpoint::RxBLEModel, 32, 500))

--- a/buttplug/src/server/device/protocol/mysteryvibe.rs
+++ b/buttplug/src/server/device/protocol/mysteryvibe.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/mysteryvibe_v2.rs
+++ b/buttplug/src/server/device/protocol/mysteryvibe_v2.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/nintendo_joycon.rs
+++ b/buttplug/src/server/device/protocol/nintendo_joycon.rs
@@ -1,3 +1,4 @@
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 #[cfg(feature = "wasm")]
 use crate::util;
 use crate::{

--- a/buttplug/src/server/device/protocol/nobra.rs
+++ b/buttplug/src/server/device/protocol/nobra.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/patoo.rs
+++ b/buttplug/src/server/device/protocol/patoo.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,
@@ -44,6 +47,7 @@ impl ProtocolIdentifier for PatooIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     // Patoo Love devices have wildcarded names of ([A-Z]+)\d*
     // Force the identifier lookup to the non-numeric portion

--- a/buttplug/src/server/device/protocol/prettylove.rs
+++ b/buttplug/src/server/device/protocol/prettylove.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{
@@ -41,6 +44,7 @@ impl ProtocolIdentifier for PrettyLoveIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     Ok((
       UserDeviceIdentifier::new(

--- a/buttplug/src/server/device/protocol/svakom_avaneo.rs
+++ b/buttplug/src/server/device/protocol/svakom_avaneo.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_dt250a.rs
+++ b/buttplug/src/server/device/protocol/svakom_dt250a.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_iker.rs
+++ b/buttplug/src/server/device/protocol/svakom_iker.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_sam.rs
+++ b/buttplug/src/server/device/protocol/svakom_sam.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_suitcase.rs
+++ b/buttplug/src/server/device/protocol/svakom_suitcase.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_tarax.rs
+++ b/buttplug/src/server/device/protocol/svakom_tarax.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/svakom_v5.rs
+++ b/buttplug/src/server/device/protocol/svakom_v5.rs
@@ -7,7 +7,10 @@
 
 use crate::core::message::ActuatorType;
 use crate::core::message::ActuatorType::{Oscillate, Vibrate};
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::server::device::hardware::Hardware;
 use crate::server::device::protocol::ProtocolIdentifier;
 use crate::server::device::protocol::ProtocolInitializer;

--- a/buttplug/src/server/device/protocol/thehandy/mod.rs
+++ b/buttplug/src/server/device/protocol/thehandy/mod.rs
@@ -8,7 +8,10 @@
 use self::handyplug::Ping;
 
 use super::fleshlight_launch_helper;
-use crate::server::device::configuration::ProtocolDeviceAttributes;
+use crate::server::device::configuration::{
+  ProtocolCommunicationSpecifier,
+  ProtocolDeviceAttributes,
+};
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/vibcrafter.rs
+++ b/buttplug/src/server/device/protocol/vibcrafter.rs
@@ -27,6 +27,7 @@ use ecb::cipher::block_padding::Pkcs7;
 use ecb::cipher::{BlockDecryptMut, BlockEncryptMut, KeyInit};
 use std::sync::Arc;
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use regex::Regex;

--- a/buttplug/src/server/device/protocol/vibratissimo.rs
+++ b/buttplug/src/server/device/protocol/vibratissimo.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,
@@ -43,6 +44,7 @@ impl ProtocolIdentifier for VibratissimoIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     let result = hardware
       .read_value(&HardwareReadCmd::new(Endpoint::RxBLEModel, 128, 500))

--- a/buttplug/src/server/device/protocol/vorze_sa.rs
+++ b/buttplug/src/server/device/protocol/vorze_sa.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/wetoy.rs
+++ b/buttplug/src/server/device/protocol/wetoy.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{

--- a/buttplug/src/server/device/protocol/wevibe.rs
+++ b/buttplug/src/server/device/protocol/wevibe.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{
     errors::ButtplugDeviceError,

--- a/buttplug/src/server/device/protocol/youou.rs
+++ b/buttplug/src/server/device/protocol/youou.rs
@@ -5,6 +5,7 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
+use crate::server::device::configuration::ProtocolCommunicationSpecifier;
 use crate::{
   core::{errors::ButtplugDeviceError, message::Endpoint},
   server::device::{
@@ -43,6 +44,7 @@ impl ProtocolIdentifier for YououIdentifier {
   async fn identify(
     &mut self,
     hardware: Arc<Hardware>,
+    _: ProtocolCommunicationSpecifier,
   ) -> Result<(UserDeviceIdentifier, Box<dyn ProtocolInitializer>), ButtplugDeviceError> {
     Ok((
       UserDeviceIdentifier::new(hardware.address(), "Youou", &Some("VX001_".to_owned())),

--- a/buttplug/src/server/device/server_device.rs
+++ b/buttplug/src/server/device/server_device.rs
@@ -155,8 +155,9 @@ impl ServerDevice {
     let mut protocol_identifier_stage = protocol_identifier.unwrap();
     let hardware = Arc::new(hardware_out.unwrap());
 
-    let (identifier, mut protocol_initializer) =
-      protocol_identifier_stage.identify(hardware.clone()).await?;
+    let (identifier, mut protocol_initializer) = protocol_identifier_stage
+      .identify(hardware.clone(), hardware_connector.specifier())
+      .await?;
 
     // Now we have an identifier. After this point, if anything fails, consider it a complete
     // connection failure, as identify may have already run commands on the device, and therefore


### PR DESCRIPTION
This change passes the ProtocolCommunicationSpecifier down into ProtocolIdentifier::identify(), which affects all protocols, but means that the identify() method can access the same data that was used to decide that this was a suitable protocol implementation in the first place.

Fixes #547