### PR TITLE
Add more sistalk monsterpub devices and sensors for them

### DIFF
--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
@@ -8965,7 +8965,30 @@
           ]
         }
       },
-      "configurations": [
+      "configurations": [{
+        "identifier": [
+          "MP2_JK_N0_P1"
+        ],
+        "name": "Sistalk MonsterPub 2 Doctor Whale 2",
+        "messages": {
+          "ScalarCmd": [
+            {
+              "StepRange": [
+                0,
+                100
+              ],
+              "ActuatorType": "Vibrate"
+            },
+            {
+              "StepRange": [
+                0,
+                100
+              ],
+              "ActuatorType": "Vibrate"
+            }
+          ]
+        }
+      },
         {
           "identifier": [
             "MP2_JK_N_P1"

--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
@@ -8948,6 +8948,9 @@
           },
           "00008000-0000-1000-8000-00805f9b34fb": {
             "rx": "00008001-0000-1000-8000-00805f9b34fb"
+          },
+          "00006050-0000-1000-8000-00805f9b34fb": {
+            "rxblebattery": "00006051-0000-1000-8000-00805f9b34fb"
           }
         }
       },
@@ -8965,30 +8968,7 @@
           ]
         }
       },
-      "configurations": [{
-        "identifier": [
-          "MP2_JK_N0_P1"
-        ],
-        "name": "Sistalk MonsterPub 2 Doctor Whale 2",
-        "messages": {
-          "ScalarCmd": [
-            {
-              "StepRange": [
-                0,
-                100
-              ],
-              "ActuatorType": "Vibrate"
-            },
-            {
-              "StepRange": [
-                0,
-                100
-              ],
-              "ActuatorType": "Vibrate"
-            }
-          ]
-        }
-      },
+      "configurations": [
         {
           "identifier": [
             "MP2_JK_N_P1"
@@ -9009,6 +8989,18 @@
                   100
                 ],
                 "ActuatorType": "Vibrate"
+              }
+            ],
+            "SensorReadCmd": [
+              {
+                "FeatureDescriptor": "Battery Level",
+                "SensorType": "Battery",
+                "SensorRange": [
+                  [
+                    0,
+                    100
+                  ]
+                ]
               }
             ]
           }
@@ -9095,7 +9087,30 @@
           "identifier": [
             "MP1N_QC_TL_P2"
           ],
-          "name": "Sistalk MonsterPub BeatHeart"
+          "name": "Sistalk MonsterPub BeatHeart",
+          "messages": {
+            "ScalarCmd": [
+              {
+                "StepRange": [
+                  0,
+                  100
+                ],
+                "ActuatorType": "Vibrate"
+              }
+            ],
+            "SensorReadCmd": [
+              {
+                "FeatureDescriptor": "Battery Level",
+                "SensorType": "Battery",
+                "SensorRange": [
+                  [
+                    0,
+                    100
+                  ]
+                ]
+              }
+            ]
+          }
         }
       ]
     },

--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
@@ -13463,6 +13463,68 @@
       "configurations": [
         {
           "identifier": [
+            "MP2_JK_N0_P1"
+          ],
+          "name": "Sistalk MonsterPub 2 Doctor Whale Premium",
+          "features": [
+            {
+              "feature-type": "Vibrate",
+              "actuator": {
+                "step-range": [
+                  0,
+                  100
+                ],
+                "messages": [
+                  "ScalarCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Vibrate",
+              "actuator": {
+                "step-range": [
+                  0,
+                  100
+                ],
+                "messages": [
+                  "ScalarCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Battery",
+              "description": "Battery Level",
+              "sensor": {
+                "value-range": [
+                  [
+                    0,
+                    100
+                  ]
+                ],
+                "messages": [
+                  "SensorReadCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Pressure",
+              "description": "Pressure sensor",
+              "sensor": {
+                "value-range": [
+                  [
+                    0,
+                    2047
+                  ]
+                ],
+                "messages": [
+                  "SensorReadCmd"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "identifier": [
             "MP2_JK_N_P1"
           ],
           "name": "Sistalk MonsterPub 2 Doctor Whale",
@@ -13559,6 +13621,53 @@
         },
         {
           "identifier": [
+            "MP2_QC_N_P1"
+          ],
+          "name": "Sistalk MonsterPub 2 Master Godkilla",
+          "features": [
+            {
+              "feature-type": "Vibrate",
+              "actuator": {
+                "step-range": [
+                  0,
+                  100
+                ],
+                "messages": [
+                  "ScalarCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Vibrate",
+              "actuator": {
+                "step-range": [
+                  0,
+                  100
+                ],
+                "messages": [
+                  "ScalarCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Battery",
+              "description": "Battery Level",
+              "sensor": {
+                "value-range": [
+                  [
+                    0,
+                    100
+                  ]
+                ],
+                "messages": [
+                  "SensorReadCmd"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "identifier": [
             "MP_BABY_QC_N_P4"
           ],
           "name": "Sistalk MonsterPub Baby Youth Health",
@@ -13599,7 +13708,36 @@
           "identifier": [
             "MP1N_QC_TL_P2"
           ],
-          "name": "Sistalk MonsterPub BeatHeart"
+          "name": "Sistalk MonsterPub BeatHeart",
+          "features": [
+            {
+              "feature-type": "Vibrate",
+              "actuator": {
+                "step-range": [
+                  0,
+                  100
+                ],
+                "messages": [
+                  "ScalarCmd"
+                ]
+              }
+            },
+            {
+              "feature-type": "Battery",
+              "description": "Battery Level",
+              "sensor": {
+                "value-range": [
+                  [
+                    0,
+                    100
+                  ]
+                ],
+                "messages": [
+                  "SensorReadCmd"
+                ]
+              }
+            }
+          ]
         }
       ],
       "communication": [
@@ -13619,6 +13757,12 @@
               },
               "00008000-0000-1000-8000-00805f9b34fb": {
                 "rx": "00008001-0000-1000-8000-00805f9b34fb"
+              },
+              "00006050-0000-1000-8000-00805f9b34fb": {
+                "rxblebattery": "00006051-0000-1000-8000-00805f9b34fb"
+              },
+              "00006030-0000-1000-8000-00805f9b34fb": {
+                "rxpressure": "00006031-0000-1000-8000-00805f9b34fb"
               }
             }
           }

--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
@@ -13463,9 +13463,10 @@
       "configurations": [
         {
           "identifier": [
+            "MP2_JK_N_P1",
             "MP2_JK_N0_P1"
           ],
-          "name": "Sistalk MonsterPub 2 Doctor Whale Premium",
+          "name": "Sistalk MonsterPub 2 Doctor Whale",
           "features": [
             {
               "feature-type": "Vibrate",
@@ -13518,38 +13519,6 @@
                 ],
                 "messages": [
                   "SensorReadCmd"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "identifier": [
-            "MP2_JK_N_P1"
-          ],
-          "name": "Sistalk MonsterPub 2 Doctor Whale",
-          "features": [
-            {
-              "feature-type": "Vibrate",
-              "actuator": {
-                "step-range": [
-                  0,
-                  100
-                ],
-                "messages": [
-                  "ScalarCmd"
-                ]
-              }
-            },
-            {
-              "feature-type": "Vibrate",
-              "actuator": {
-                "step-range": [
-                  0,
-                  100
-                ],
-                "messages": [
-                  "ScalarCmd"
                 ]
               }
             }
@@ -13623,7 +13592,7 @@
           "identifier": [
             "MP2_QC_N_P1"
           ],
-          "name": "Sistalk MonsterPub 2 Master Godkilla",
+          "name": "Sistalk MonsterPub 2 Master Godzilla",
           "features": [
             {
               "feature-type": "Vibrate",

--- a/buttplug/buttplug-device-config/device-config-v2/buttplug-device-config-v2.yml
+++ b/buttplug/buttplug-device-config/device-config-v2/buttplug-device-config-v2.yml
@@ -4459,6 +4459,8 @@ protocols:
           rxblemodel: 00006014-0000-1000-8000-00805f9b34fb
         00008000-0000-1000-8000-00805f9b34fb:
           rx: 00008001-0000-1000-8000-00805f9b34fb
+        00006050-0000-1000-8000-00805f9b34fb:
+          rxblebattery: 00006051-0000-1000-8000-00805f9b34fb
     defaults:
       name: Sistalk MonsterPub Device
       messages:
@@ -4468,6 +4470,7 @@ protocols:
     configurations:
       - identifier:
           - MP2_JK_N_P1
+          - MP2_JK_N0_P1
         name: Sistalk MonsterPub 2 Doctor Whale
         messages:
           ScalarCmd:
@@ -4475,6 +4478,10 @@ protocols:
               ActuatorType: Vibrate
             - StepRange: [0, 100]
               ActuatorType: Vibrate
+          SensorReadCmd:
+            - FeatureDescriptor: Battery Level
+              SensorType: Battery
+              SensorRange: [ [ 0, 100 ] ]
       - identifier:
           - MP_MW_TL_P2
         name: Sistalk MonsterPub Magic Kiss
@@ -4508,6 +4515,14 @@ protocols:
       - identifier:
           - MP1N_QC_TL_P2
         name: Sistalk MonsterPub BeatHeart
+        messages:
+          ScalarCmd:
+            - StepRange: [ 0, 100 ]
+              ActuatorType: Vibrate
+          SensorReadCmd:
+            - FeatureDescriptor: Battery Level
+              SensorType: Battery
+              SensorRange: [ [ 0, 100 ] ]
   joyhub:
     btle:
       names:

--- a/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
+++ b/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
@@ -7699,6 +7699,40 @@ protocols:
               - ScalarCmd
     configurations:
       - identifier:
+          - MP2_JK_N0_P1
+        name: Sistalk MonsterPub 2 Doctor Whale Premium
+        features:
+          - feature-type: Vibrate
+            actuator:
+              step-range:
+                - 0
+                - 100
+              messages:
+                - ScalarCmd
+          - feature-type: Vibrate
+            actuator:
+              step-range:
+                - 0
+                - 100
+              messages:
+                - ScalarCmd
+          - feature-type: Battery
+            description: Battery Level
+            sensor:
+              value-range:
+                - - 0
+                  - 100
+              messages:
+                - SensorReadCmd
+          - feature-type: Pressure
+            description: Pressure sensor
+            sensor:
+              value-range:
+                - - 0
+                  - 2047
+              messages:
+                - SensorReadCmd
+      - identifier:
           - MP2_JK_N_P1
         name: Sistalk MonsterPub 2 Doctor Whale
         features:
@@ -7753,6 +7787,32 @@ protocols:
               messages:
                 - ScalarCmd
       - identifier:
+          - MP2_QC_N_P1
+        name: Sistalk MonsterPub 2 Master Godkilla
+        features:
+          - feature-type: Vibrate
+            actuator:
+              step-range:
+                - 0
+                - 100
+              messages:
+                - ScalarCmd
+          - feature-type: Vibrate
+            actuator:
+              step-range:
+                - 0
+                - 100
+              messages:
+                - ScalarCmd
+          - feature-type: Battery
+            description: Battery Level
+            sensor:
+              value-range:
+                - - 0
+                  - 100
+              messages:
+                - SensorReadCmd
+      - identifier:
           - MP_BABY_QC_N_P4
         name: Sistalk MonsterPub Baby Youth Health
         features:
@@ -7776,6 +7836,22 @@ protocols:
       - identifier:
           - MP1N_QC_TL_P2
         name: Sistalk MonsterPub BeatHeart
+        features:
+          - feature-type: Vibrate
+            actuator:
+              step-range:
+                - 0
+                - 100
+              messages:
+                - ScalarCmd
+          - feature-type: Battery
+            description: Battery Level
+            sensor:
+              value-range:
+                - - 0
+                  - 100
+              messages:
+                - SensorReadCmd
     communication:
       - btle:
           names:
@@ -7789,6 +7865,10 @@ protocols:
               rxblemodel: 00006014-0000-1000-8000-00805f9b34fb
             00008000-0000-1000-8000-00805f9b34fb:
               rx: 00008001-0000-1000-8000-00805f9b34fb
+            00006050-0000-1000-8000-00805f9b34fb:
+              rxblebattery: 00006051-0000-1000-8000-00805f9b34fb
+            00006030-0000-1000-8000-00805f9b34fb:
+              rxpressure: 00006031-0000-1000-8000-00805f9b34fb
   joyhub:
     defaults:
       name: JoyHub Device

--- a/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
+++ b/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
@@ -7699,8 +7699,9 @@ protocols:
               - ScalarCmd
     configurations:
       - identifier:
+          - MP2_JK_N_P1
           - MP2_JK_N0_P1
-        name: Sistalk MonsterPub 2 Doctor Whale Premium
+        name: Sistalk MonsterPub 2 Doctor Whale
         features:
           - feature-type: Vibrate
             actuator:
@@ -7732,24 +7733,6 @@ protocols:
                   - 2047
               messages:
                 - SensorReadCmd
-      - identifier:
-          - MP2_JK_N_P1
-        name: Sistalk MonsterPub 2 Doctor Whale
-        features:
-          - feature-type: Vibrate
-            actuator:
-              step-range:
-                - 0
-                - 100
-              messages:
-                - ScalarCmd
-          - feature-type: Vibrate
-            actuator:
-              step-range:
-                - 0
-                - 100
-              messages:
-                - ScalarCmd
       - identifier:
           - MP_MW_TL_P2
         name: Sistalk MonsterPub Magic Kiss
@@ -7788,7 +7771,7 @@ protocols:
                 - ScalarCmd
       - identifier:
           - MP2_QC_N_P1
-        name: Sistalk MonsterPub 2 Master Godkilla
+        name: Sistalk MonsterPub 2 Master Godzilla
         features:
           - feature-type: Vibrate
             actuator:


### PR DESCRIPTION
Added a few devices that I own and could reverse engineer

Tested with intiface-engine and a python script.

I wanted to add subscriptions to newly added sensors, but couldn't find any mention of SensorSubscribeCmd in `buttplug-device-config-v3.yml`