### PR TITLE
Add support for Lelo F1S V3

### DIFF
--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v2.json
@@ -4942,7 +4942,8 @@
       "btle": {
         "names": [
           "F1SV2A",
-          "F1SV2X"
+          "F1SV2X",
+          "F1SV3"
         ],
         "services": {
           "0000fff0-0000-1000-8000-00805f9b34fb": {

--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
@@ -6383,7 +6383,8 @@
           "btle": {
             "names": [
               "F1SV2A",
-              "F1SV2X"
+              "F1SV2X",
+              "F1SV3"
             ],
             "services": {
               "0000fff0-0000-1000-8000-00805f9b34fb": {

--- a/buttplug/buttplug-device-config/device-config-v2/buttplug-device-config-v2.yml
+++ b/buttplug/buttplug-device-config/device-config-v2/buttplug-device-config-v2.yml
@@ -2467,6 +2467,7 @@ protocols:
       names:
         - F1SV2A
         - F1SV2X
+        - F1SV3
       services:
         0000fff0-0000-1000-8000-00805f9b34fb:
           tx: 0000fff1-0000-1000-8000-00805f9b34fb

--- a/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
+++ b/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
@@ -3637,6 +3637,7 @@ protocols:
           names:
             - F1SV2A
             - F1SV2X
+            - F1SV3
           services:
             0000fff0-0000-1000-8000-00805f9b34fb:
               tx: 0000fff1-0000-1000-8000-00805f9b34fb


### PR DESCRIPTION
Verified works with existing protocol, only the BTLE name has changed.