### PR TITLE
Feat: Add support for Yiciyuan device

### DIFF
--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
@@ -18577,6 +18577,75 @@
           }
         }
       ]
+    },
+    "yiciyuan": {
+      "defaults": {
+        "name": "YiCiYuan Device",
+        "features": [
+          {
+            "feature-type": "Vibrate",
+            "actuator": {
+              "step-range": [
+                0,
+                20
+              ],
+              "messages": [
+                "ScalarCmd"
+              ]
+            }
+          }
+        ]
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "YS-TD-01"
+          ],
+          "name": "YiCiYuan Vibrator 01"
+        },
+        {
+          "identifier": [
+            "YS-TD-02"
+          ],
+          "name": "YiCiYuan Vibrator 02"
+        },
+        {
+          "identifier": [
+            "YS-TD-03"
+          ],
+          "name": "YiCiYuan Vibrator 03"
+        },
+        {
+          "identifier": [
+            "YCY-FJB-01"
+          ],
+          "name": "YiCiYuan Masturbation Cup 01"
+        },
+        {
+          "identifier": [
+            "YCY-FJB-02"
+          ],
+          "name": "YiCiYuan Masturbation Cup 02"
+        }
+      ],
+      "communication": [
+        {
+          "btle": {
+            "names": [
+              "YS-TD-01",
+              "YS-TD-02",
+              "YS-TD-03",
+              "YCY-FJB-01",
+              "YCY-FJB-02"
+            ],
+            "services": {
+              "0000ff40-0000-1000-8000-00805f9b34fb": {
+                "tx": "0000ff41-0000-1000-8000-00805f9b34fb"
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
+++ b/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
@@ -10651,3 +10651,41 @@ protocols:
           services:
             0000ffb0-0000-1000-8000-00805f9b34fb:
               tx: 0000ffb2-0000-1000-8000-00805f9b34fb
+  yiciyuan:
+    defaults:
+      name: YiCiYuan Device
+      features:
+        - feature-type: Vibrate
+          actuator:
+            step-range:
+              - 0
+              - 20
+            messages:
+              - ScalarCmd
+    configurations:
+      - identifier:
+          - YS-TD-01
+        name: YiCiYuan Vibrator 01
+      - identifier:
+          - YS-TD-02
+        name: YiCiYuan Vibrator 02
+      - identifier:
+          - YS-TD-03
+        name: YiCiYuan Vibrator 03
+      - identifier:
+          - YCY-FJB-01
+        name: YiCiYuan Masturbation Cup 01
+      - identifier:
+          - YCY-FJB-02
+        name: YiCiYuan Masturbation Cup 02
+    communication:
+      - btle:
+          names:
+            - YS-TD-01
+            - YS-TD-02
+            - YS-TD-03
+            - YCY-FJB-01
+            - YCY-FJB-02
+          services:
+            0000ff40-0000-1000-8000-00805f9b34fb:
+              tx: 0000ff41-0000-1000-8000-00805f9b34fb

--- a/buttplug/src/server/device/protocol/mod.rs
+++ b/buttplug/src/server/device/protocol/mod.rs
@@ -140,6 +140,7 @@ pub mod xibao;
 pub mod xinput;
 pub mod xiuxiuda;
 pub mod xuanhuan;
+pub mod yiciyuan;
 pub mod youcups;
 pub mod youou;
 pub mod zalo;
@@ -651,6 +652,7 @@ pub fn get_default_protocol_map() -> HashMap<String, Arc<dyn ProtocolIdentifierF
     &mut map,
     youcups::setup::YoucupsIdentifierFactory::default(),
   );
+  add_to_protocol_map(&mut map, yiciyuan::setup::YiciyuanIdentifierFactory::default());
   add_to_protocol_map(&mut map, youou::setup::YououIdentifierFactory::default());
   add_to_protocol_map(&mut map, zalo::setup::ZaloIdentifierFactory::default());
   add_to_protocol_map(

--- a/buttplug/src/server/device/protocol/yiciyuan.rs
+++ b/buttplug/src/server/device/protocol/yiciyuan.rs
@@ -1,0 +1,43 @@
+// Buttplug Rust Source Code File - See https://buttplug.io for more info.
+//
+// Copyright 2016-2024 Nonpolynomial Labs LLC. All rights reserved.
+//
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root
+// for full license information.
+
+use crate::{
+  core::{
+    errors::ButtplugDeviceError,
+    message::Endpoint,
+  },
+  server::device::{
+    hardware::{HardwareCommand, HardwareWriteCmd},
+    protocol::{generic_protocol_setup, ProtocolHandler},
+  },
+};
+
+generic_protocol_setup!(Yiciyuan, "yiciyuan");
+
+#[derive(Default)]
+pub struct Yiciyuan {}
+
+impl ProtocolHandler for Yiciyuan {
+  fn keepalive_strategy(&self) -> super::ProtocolKeepaliveStrategy {
+    super::ProtocolKeepaliveStrategy::RepeatLastPacketStrategy
+  }
+
+  fn handle_scalar_vibrate_cmd(
+    &self,
+    _index: u32,
+    scalar: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    let mut cmd = vec![0x35, 0x12, scalar as u8];
+    cmd.resize(16, 0);
+    Ok(vec![HardwareWriteCmd::new(
+      Endpoint::Tx,
+      cmd,
+      false,
+    )
+    .into()])
+  }
+}

--- a/buttplug/tests/test_device_protocols.rs
+++ b/buttplug/tests/test_device_protocols.rs
@@ -409,6 +409,7 @@ async fn test_device_protocols_embedded_v2(test_file: &str) {
 #[test_case("test_fleshy_thrust_protocol.yaml" ; "Fleshy Thrust Sync Protocol")]
 #[test_case("test_nexus_revo.yaml" ; "Nexus Revo Protocol")]
 #[test_case("test_omobo_protocol.yaml" ; "Omobo Protocol")]
+#[test_case("test_yiciyuan_protocol.yaml" ; "Yiciyuan Protocol")]
 #[tokio::test]
 async fn test_device_protocols_json_v2(test_file: &str) {
   util::device_test::client::client_v2::run_json_test_case(&load_test_case(test_file).await).await;

--- a/buttplug/tests/util/device_test/device_test_case/test_yiciyuan_protocol.yaml
+++ b/buttplug/tests/util/device_test/device_test_case/test_yiciyuan_protocol.yaml
@@ -1,0 +1,56 @@
+devices:
+  - identifier: 
+      name: "YCY-FJB-02"
+    expected_name: "YiCiYuan Masturbation Cup 02"
+device_commands:
+  # Commands
+  - !Messages
+      device_index: 0
+      messages: 
+        - !Vibrate
+          - Index: 0
+            Speed: 0.5
+  - !Commands
+      device_index: 0
+      commands: 
+        - !Write
+            endpoint: tx
+            data: [0x35, 0x12, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+            write_with_response: false
+  - !Messages
+      device_index: 0
+      messages:
+        - !Vibrate
+          - Index: 0
+            Speed: 0.1
+  - !Commands
+      device_index: 0
+      commands:
+        - !Write
+            endpoint: tx
+            data: [0x35, 0x12, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+            write_with_response: false
+  - !Messages
+      device_index: 0
+      messages:
+        - !Vibrate
+          - Index: 0
+            Speed: 1.0
+  - !Commands
+      device_index: 0
+      commands:
+        - !Write
+            endpoint: tx
+            data: [0x35, 0x12, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+            write_with_response: false
+  - !Messages
+      device_index: 0
+      messages:
+        - !Stop
+  - !Commands
+      device_index: 0
+      commands:
+        - !Write
+            endpoint: tx
+            data: [0x35, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+            write_with_response: false


### PR DESCRIPTION
Add support for YiCiYuan(役次元) devices, I have tested it with YCY-FJB-02. And all devices are sharing the same protocol.

YiCiYuan is a sextoy manufacturer from China, their products include Masturbation Cup and Vibrator.

You can get info about these devices from [website](https://suo.jiushu1234.com/m/#/) and X (https://x.com/chastitybeltsex).