### PR TITLE
Add Support for Urica Guard v1

### DIFF
--- a/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
+++ b/buttplug/buttplug-device-config/build-config/buttplug-device-config-v3.json
@@ -15442,6 +15442,12 @@
         },
         {
           "identifier": [
+            "J-Derik"
+          ],
+          "name": "JoyHub Urica Guard"
+        },
+        {
+          "identifier": [
             "J-UricaGuard2"
           ],
           "name": "JoyHub Urica Guard 2"
@@ -15967,7 +15973,8 @@
               "J-MarsLion2",
               "J-Myrna",
               "J-Vase2",
-              "J-Martino"
+              "J-Martino",
+              "J-Derik"
             ],
             "services": {
               "0000ffa0-0000-1000-8000-00805f9b34fb": {

--- a/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
+++ b/buttplug/buttplug-device-config/device-config-v3/buttplug-device-config-v3.yml
@@ -8835,6 +8835,9 @@ protocols:
           - J-Tarik
         name: JoyHub Tarik
       - identifier:
+          - J-Derik
+        name: JoyHub Urica Guard
+      - identifier:
           - J-UricaGuard2
         name: JoyHub Urica Guard 2
       - identifier:
@@ -9151,6 +9154,7 @@ protocols:
             - J-Myrna
             - J-Vase2
             - J-Martino
+            - J-Derik
           services:
             0000ffa0-0000-1000-8000-00805f9b34fb:
               tx: 0000ffa1-0000-1000-8000-00805f9b34fb


### PR DESCRIPTION
Wierdly enough, this seems to be the only Joyhub device that has a different Bluetooth name than it is called.