### PR TITLE
Make StartScanning error more helpful

### DIFF
--- a/buttplug/src/server/device/hardware/communication/btleplug/btleplug_adapter_task.rs
+++ b/buttplug/src/server/device/hardware/communication/btleplug/btleplug_adapter_task.rs
@@ -255,7 +255,7 @@ impl BtleplugAdapterTask {
               BtleplugAdapterCommand::StartScanning => {
                 tried_addresses.clear();
                 if let Err(err) = adapter.start_scan(ScanFilter::default()).await {
-                  error!("Start scanning request failed: {}", err);
+                  error!("Start scanning request failed. Ensure Bluetooth is enabled and permissions are granted: {}", err);
                 }
               }
               BtleplugAdapterCommand::StopScanning => {


### PR DESCRIPTION
This can throw simply because bluetooth isn't enabled on the device or bluetooth is blocked due to lacking permissions.

It seems sensible to let the user know to check this. Fixing it can be as easy as clicking one button but the error isn't very helpful and makes it seem like there's something wrong with the library/program utilizing it. Especially for less technical users.
