### PR TITLE
feat: add battery reading for wevibe devices

### DIFF
--- a/crates/buttplug_server/src/device/protocol_impl/wevibe.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/wevibe.rs
@@ -6,7 +6,7 @@
 // for full license information.
 
 use crate::device::{
-  hardware::{Hardware, HardwareCommand, HardwareWriteCmd},
+  hardware::{Hardware, HardwareCommand, HardwareReadCmd, HardwareWriteCmd},
   protocol::{
     ProtocolHandler,
     ProtocolIdentifier,
@@ -16,13 +16,14 @@ use crate::device::{
 };
 use async_trait::async_trait;
 use buttplug_core::errors::ButtplugDeviceError;
-use buttplug_core::message::OutputType;
+use buttplug_core::message::{InputReadingV4, InputTypeReading, InputValue, OutputType};
 use buttplug_server_device_config::Endpoint;
 use buttplug_server_device_config::{
   ProtocolCommunicationSpecifier,
   ServerDeviceDefinition,
   UserDeviceIdentifier,
 };
+use futures_util::{FutureExt, future::BoxFuture};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use uuid::{Uuid, uuid};
@@ -112,5 +113,42 @@ impl ProtocolHandler for WeVibe {
     Ok(vec![
       HardwareWriteCmd::new(&[WEVIBE_PROTOCOL_UUID], Endpoint::Tx, data, true).into(),
     ])
+  }
+
+  fn handle_battery_level_cmd(
+    &self,
+    device_index: u32,
+    device: Arc<Hardware>,
+    feature_index: u32,
+    feature_id: Uuid,
+  ) -> BoxFuture<'_, Result<InputReadingV4, ButtplugDeviceError>> {
+    debug!("Trying to get battery reading.");
+    let fut = device.read_value(&HardwareReadCmd::new(feature_id, Endpoint::Rx, 8, 500));
+    async move {
+      let hw_msw = fut.await?;
+      let data = hw_msw.data();
+      if data.len() != 8 {
+        return Err(ButtplugDeviceError::DeviceCommunicationError(
+          "Wevibe battery data not expected length!".to_owned(),
+        ));
+      }
+      // based on https://gist.github.com/bnm12/fcdcef291a500bf51cef734aa1830e4d
+      let xx = data[3] as i32;
+      let zz = data[2] as i32;
+      let mut y = (xx << 8) + zz;
+      if y < 0 {
+        y += 0x10000;
+      }
+      let battery_level = y * 100 / 0xFFFF;
+
+      let battery_reading = InputReadingV4::new(
+        device_index,
+        feature_index,
+        InputTypeReading::Battery(InputValue::new(battery_level as u8)),
+      );
+      debug!("Got battery reading: {}", battery_level);
+      Ok(battery_reading)
+    }
+    .boxed()
   }
 }

--- a/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
+++ b/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
@@ -1,7 +1,7 @@
 {
   "version": {
     "major": 4,
-    "minor": 176
+    "minor": 177
   },
   "protocols": {
     "activejoy": {
@@ -22321,6 +22321,24 @@
                   ]
                 }
               }
+            },
+            {
+              "description": "battery Level",
+              "id": "92acc28c-5c54-4c61-be26-d9d8443288e3",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
+                  ]
+                }
+              }
             }
           ],
           "id": "11cd7b68-2c94-4fc8-837f-09d47214cee1",
@@ -22359,6 +22377,24 @@
                   ]
                 }
               }
+            },
+            {
+              "description": "battery Level",
+              "id": "1a971255-fcda-446f-9a94-d1f400e0e8b9",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
+                  ]
+                }
+              }
             }
           ],
           "id": "400ef30a-63eb-4648-b293-c7ecc874f509",
@@ -22392,6 +22428,24 @@
                   ]
                 }
               }
+            },
+            {
+              "description": "battery Level",
+              "id": "cdf9b997-2430-4120-b836-3af64a9ad170",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
+                  ]
+                }
+              }
             }
           ],
           "id": "b667bb6a-46b1-4534-8c79-83aa0749028a",
@@ -22422,6 +22476,24 @@
                   "value": [
                     0,
                     15
+                  ]
+                }
+              }
+            },
+            {
+              "description": "battery Level",
+              "id": "7c0cfd3f-6bd1-4081-95b1-1a6d53b3c2d3",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
                   ]
                 }
               }

--- a/crates/buttplug_server_device_config/device-config-v4/protocols/wevibe.yml
+++ b/crates/buttplug_server_device_config/device-config-v4/protocols/wevibe.yml
@@ -62,6 +62,16 @@ configurations:
         - 0
         - 15
     index: 1
+  - description: battery Level
+    id: 92acc28c-5c54-4c61-be26-d9d8443288e3
+    input:
+      battery:
+        value:
+          - - 0
+            - 100
+        command:
+          - Read
+    index: 2
   id: 11cd7b68-2c94-4fc8-837f-09d47214cee1
 - identifier:
   - Gala
@@ -81,6 +91,16 @@ configurations:
         - 0
         - 15
     index: 1
+  - description: battery Level
+    id: 1a971255-fcda-446f-9a94-d1f400e0e8b9
+    input:
+      battery:
+        value:
+          - - 0
+            - 100
+        command:
+          - Read
+    index: 2
   id: 400ef30a-63eb-4648-b293-c7ecc874f509
 - identifier:
   - Nova
@@ -100,6 +120,16 @@ configurations:
         - 0
         - 15
     index: 1
+  - description: battery Level
+    id: cdf9b997-2430-4120-b836-3af64a9ad170
+    input:
+      battery:
+        value:
+          - - 0
+            - 100
+        command:
+          - Read
+    index: 2
   id: b667bb6a-46b1-4534-8c79-83aa0749028a
 - identifier:
   - Sync
@@ -119,6 +149,16 @@ configurations:
         - 0
         - 15
     index: 1
+  - description: battery Level
+    id: 7c0cfd3f-6bd1-4081-95b1-1a6d53b3c2d3
+    input:
+      battery:
+        value:
+          - - 0
+            - 100
+        command:
+          - Read
+    index: 2
   id: 0e72dab3-4b87-4bae-ae02-aae0bbb0f035
 communication:
 - btle:

--- a/crates/buttplug_server_device_config/device-config-v4/version.yaml
+++ b/crates/buttplug_server_device_config/device-config-v4/version.yaml
@@ -1,3 +1,3 @@
 version:
   major: 4
-  minor: 176
+  minor: 177


### PR DESCRIPTION
Added a basic battery reading based on the protocol descriptions from [Protocols / We-Vibe](https://buttplug.io/stpihkal/protocols/we-vibe/#sources​). 

I did a test using a We-Vibe Sync and verified values with We-Vibe app.