### PR TITLE
feat: Add MyMuse Link Plus device support

### DIFF
--- a/crates/buttplug_server/src/device/protocol_impl/mod.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/mod.rs
@@ -77,6 +77,7 @@ pub mod mizzzee_v2;
 pub mod mizzzee_v3;
 pub mod monsterpub;
 pub mod motorbunny;
+pub mod mymuselinkplus;
 pub mod mysteryvibe;
 pub mod mysteryvibe_v2;
 pub mod nextlevelracing;
@@ -352,6 +353,7 @@ pub fn get_default_protocol_map() -> HashMap<String, Arc<dyn ProtocolIdentifierF
     &mut map,
     motorbunny::setup::MotorbunnyIdentifierFactory::default(),
   );
+  add_to_protocol_map(&mut map, mymuselinkplus::setup::MyMuseLinkPlusIdentifierFactory::default());
   add_to_protocol_map(
     &mut map,
     mysteryvibe::setup::MysteryVibeIdentifierFactory::default(),

--- a/crates/buttplug_server/src/device/protocol_impl/mymuselinkplus.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/mymuselinkplus.rs
@@ -1,0 +1,90 @@
+// Buttplug Rust Source Code File - See https://buttplug.io for more info.
+//
+// Copyright 2016-2026 Nonpolynomial Labs LLC. All rights reserved.
+//
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root
+// for full license information.
+
+use crate::device::{
+  hardware::{Hardware, HardwareCommand, HardwareWriteCmd},
+  protocol::{
+    ProtocolHandler,
+    ProtocolIdentifier,
+    ProtocolInitializer,
+    generic_protocol_initializer_setup,
+  },
+};
+use async_trait::async_trait;
+use buttplug_core::errors::ButtplugDeviceError;
+use buttplug_server_device_config::Endpoint;
+use buttplug_server_device_config::{
+  ProtocolCommunicationSpecifier,
+  ServerDeviceDefinition,
+  UserDeviceIdentifier,
+};
+use std::sync::Arc;
+use uuid::{Uuid, uuid};
+
+const MYMUSELINKPLUS_PROTOCOL_UUID: Uuid = uuid!("b8c3a1f0-7d2e-4a19-9f6b-3e8d1c5a2b40");
+generic_protocol_initializer_setup!(MyMuseLinkPlus, "mymuselinkplus");
+
+#[derive(Default)]
+pub struct MyMuseLinkPlusInitializer {}
+
+#[async_trait]
+impl ProtocolInitializer for MyMuseLinkPlusInitializer {
+  async fn initialize(
+    &mut self,
+    hardware: Arc<Hardware>,
+    _: &ServerDeviceDefinition,
+  ) -> Result<Arc<dyn ProtocolHandler>, ButtplugDeviceError> {
+    // Short vibration pulse to indicate the device is active
+    let on = HardwareWriteCmd::new(
+      &[MYMUSELINKPLUS_PROTOCOL_UUID],
+      Endpoint::Tx,
+      vec![0xAA, 0x55, 0x06, 0x01, 0x01, 0x01, 0x01, 0xFF],
+      false,
+    );
+    hardware.write_value(&on).await?;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    // Turn off
+    let off = HardwareWriteCmd::new(
+      &[MYMUSELINKPLUS_PROTOCOL_UUID],
+      Endpoint::Tx,
+      vec![0xAA, 0x55, 0x06, 0xAA, 0x00, 0x00, 0x00, 0x00],
+      false,
+    );
+    hardware.write_value(&off).await?;
+    Ok(Arc::new(MyMuseLinkPlus::default()))
+  }
+}
+
+#[derive(Default)]
+pub struct MyMuseLinkPlus {}
+
+impl ProtocolHandler for MyMuseLinkPlus {
+  fn handle_output_vibrate_cmd(
+    &self,
+    _feature_index: u32,
+    feature_id: Uuid,
+    speed: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    // Map 10 slider steps to 3 device intensity levels: SLOW(1), MEDIUM(2), FAST(3)
+    let mode = match speed {
+      0 => 0,
+      1..=3 => 1,   // SLOW
+      4..=6 => 2,   // MEDIUM
+      7..=10 => 3,  // FAST
+      _ => 3,
+    };
+    let data = if mode == 0 {
+      vec![0xAA, 0x55, 0x06, 0xAA, 0x00, 0x00, 0x00, 0x00]
+    } else {
+      vec![0xAA, 0x55, 0x06, 0x01, 0x01, 0x01, mode, 0xFF]
+    };
+
+    Ok(vec![
+      HardwareWriteCmd::new(&[feature_id], Endpoint::Tx, data, false).into(),
+    ])
+  }
+}

--- a/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
+++ b/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
@@ -1,7 +1,7 @@
 {
   "version": {
     "major": 4,
-    "minor": 180
+    "minor": 183
   },
   "protocols": {
     "activejoy": {
@@ -14788,6 +14788,44 @@
         ],
         "id": "94e9d8e0-94cc-42f5-b14d-c55cc91e2e68",
         "name": "Muse Device"
+      }
+    },
+    "mymuselinkplus": {
+      "communication": [
+        {
+          "btle": {
+            "advertised_services": [
+              "0000d34e-0000-1000-8000-00805f9b34fb"
+            ],
+            "names": [
+              "MM Massager"
+            ],
+            "services": {
+              "0000fff0-0000-1000-8000-00805f9b34fb": {
+                "tx": "0000fff1-0000-1000-8000-00805f9b34fb"
+              }
+            }
+          }
+        }
+      ],
+      "defaults": {
+        "features": [
+          {
+            "description": "Vibrator",
+            "id": "b8c3a1f0-7d2e-4a19-9f6b-3e8d1c5a2b40",
+            "index": 0,
+            "output": {
+              "vibrate": {
+                "value": [
+                  0,
+                  10
+                ]
+              }
+            }
+          }
+        ],
+        "id": "a1f0b8c3-2e7d-194a-6b9f-8d3e1c5a2b40",
+        "name": "MyMuse Link Plus"
       }
     },
     "mysteryvibe": {

--- a/crates/buttplug_server_device_config/device-config-v4/protocols/mymuselinkplus.yml
+++ b/crates/buttplug_server_device_config/device-config-v4/protocols/mymuselinkplus.yml
@@ -1,0 +1,22 @@
+---
+defaults:
+  name: MyMuse Link Plus
+  features:
+  - description: Vibrator
+    id: b8c3a1f0-7d2e-4a19-9f6b-3e8d1c5a2b40
+    output:
+      vibrate:
+        value:
+        - 0
+        - 10
+    index: 0
+  id: a1f0b8c3-2e7d-194a-6b9f-8d3e1c5a2b40
+communication:
+- btle:
+    names:
+    - MM Massager
+    advertised_services:
+    - 0000d34e-0000-1000-8000-00805f9b34fb
+    services:
+      0000fff0-0000-1000-8000-00805f9b34fb:
+        tx: 0000fff1-0000-1000-8000-00805f9b34fb

--- a/crates/buttplug_server_device_config/device-config-v4/version.yaml
+++ b/crates/buttplug_server_device_config/device-config-v4/version.yaml
@@ -1,3 +1,3 @@
 version:
   major: 4
-  minor: 180
+  minor: 183


### PR DESCRIPTION

 **New Devices:**
 * MyMuse Link Plus
 
 https://mymuse.in/products/link-plus-app-controlled-massager


 **Device Info:**
 - BLE Name: MM Massager
 - Advertised Service: 0000d34e-0000-1000-8000-00805f9b34fb
 - TX Service/Characteristic: 0000fff0 / 0000fff1

 **Protocol Details:**

 The device uses an 8-byte command format over BLE write:

```
 ┌──────┬────────────────────────────────────────────────────┐
 │ Byte │                      Purpose                       │
 ├──────┼────────────────────────────────────────────────────┤
 │ 0-1  │ Header: 0xAA 0x55                                  │
 ├──────┼────────────────────────────────────────────────────┤
 │ 2    │ Length: 0x06                                       │
 ├──────┼────────────────────────────────────────────────────┤
 │ 3    │ Mode flag: 0x01 (on) / 0xAA (stop)                 │
 ├──────┼────────────────────────────────────────────────────┤
 │ 4-5  │ Always 0x01 0x01 when on, 0x00 0x00 when off       │
 ├──────┼────────────────────────────────────────────────────┤
 │ 6    │ Intensity: 0x01 (slow), 0x02 (medium), 0x03 (fast) │
 ├──────┼────────────────────────────────────────────────────┤
 │ 7    │ Tail: 0xFF (on) / 0x00 (off)                       │
 └──────┴────────────────────────────────────────────────────┘
```



  Stop command: AA 55 06 AA 00 00 00 00
  Vibrate command: AA 55 06 01 01 01 {intensity} FF

  The device only supports 3 intensity levels, so the 0-10 buttplug scalar range is mapped as:
  - 0 → off
  - 1-3 → SLOW (1)
  - 4-6 → MEDIUM (2)
  - 7-10 → FAST (3)

  **Testing:**
  Verified with physical MyMuse Link Plus device — connection, scanning, vibration control at all levels, and stop command all confirmed working.