### PR TITLE
Improve Embedded Readiness, Runtime Portability, and Postcard-Ready Serialization

### DIFF
--- a/crates/buttplug_client/src/device/command.rs
+++ b/crates/buttplug_client/src/device/command.rs
@@ -33,6 +33,7 @@ impl From<f64> for ClientDeviceCommandValue {
   }
 }
 
+#[derive(Debug, Clone)]
 pub enum ClientDeviceOutputCommand {
   // u32 types use steps, need to compare before sending
   Vibrate(ClientDeviceCommandValue),

--- a/crates/buttplug_server/Cargo.toml
+++ b/crates/buttplug_server/Cargo.toml
@@ -46,7 +46,7 @@ uuid = { version = "1.22.0", features = ["serde", "v4"] }
 async-trait = "0.1.89"
 instant = "0.1.13"
 tokio-util = "0.7.18"
-regex = "1.12.3"
+regex-lite = "0.1.6"
 prost = "0.14.3"
 paste = "1.0.15"
 aes = { version = "0.8.4" }

--- a/crates/buttplug_server/src/device/device_task.rs
+++ b/crates/buttplug_server/src/device/device_task.rs
@@ -105,7 +105,9 @@ async fn run_device_task(
     // Calculate batch flush timeout (only if we're batching)
     let batch_fut = async {
       match batch_deadline {
-        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        Some(deadline) => {
+          async_manager::sleep(deadline.saturating_duration_since(Instant::now())).await
+        }
         None => future::pending::<()>().await,
       }
     };

--- a/crates/buttplug_server/src/device/protocol_impl/lovense/mod.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/lovense/mod.rs
@@ -249,50 +249,60 @@ fn handle_battery_level_cmd(
   feature_id: Uuid,
 ) -> BoxFuture<'static, Result<InputReadingV4, ButtplugDeviceError>> {
   let mut device_notification_receiver = device.event_stream();
+
   async move {
-    let write_fut = device.write_value(&HardwareWriteCmd::new(
-      &[feature_id],
-      Endpoint::Tx,
-      b"Battery;".to_vec(),
-      false,
-    ));
-    write_fut.await?;
-    while let Ok(event) = device_notification_receiver.recv().await {
-      match event {
-        HardwareEvent::Notification(_, _, data) => {
-          if let Ok(data_str) = std::str::from_utf8(&data) {
-            debug!("Lovense event received: {}", data_str);
-            let len = data_str.len();
-            // Depending on the state of the toy, we may get an initial
-            // character of some kind, i.e. if the toy is currently vibrating
-            // then battery level comes up as "s89;" versus just "89;". We'll
-            // need to chop the semicolon and make sure we only read the
-            // numbers in the string.
-            //
-            // Contains() is casting a wider net than we need here, but it'll
-            // do for now.
-            let start_pos = usize::from(data_str.contains('s'));
-            if let Ok(level) = data_str[start_pos..(len - 1)].parse::<u8>() {
-              return Ok(message::InputReadingV4::new(
-                device_index,
-                feature_index,
-                InputTypeReading::Battery(InputValue::new(level)),
+    device
+      .write_value(&HardwareWriteCmd::new(
+        &[feature_id],
+        Endpoint::Tx,
+        b"Battery;".to_vec(),
+        false,
+      ))
+      .await?;
+    // A timeout is required here: some Lovense devices treat battery reporting
+    // as a togglable subscription and do not promptly reply to a single Battery;
+    // query, leaving this future to hang indefinitely. See:
+    // https://github.com/buttplugio/buttplug/issues/865
+    //
+    // A fixed timeout is a known-bad workaround, but it is strictly better
+    // than hanging forever.
+    loop {
+      select! {
+        biased;
+
+        event = device_notification_receiver.recv().fuse() => {
+          match event {
+            Ok(HardwareEvent::Notification(_, _, data)) => {
+              if let Ok(data_str) = std::str::from_utf8(&data) {
+                debug!("Lovense event received: {}", data_str);
+                let len = data_str.len();
+                let start_pos = usize::from(data_str.contains('s'));
+                if let Ok(level) = data_str[start_pos..(len - 1)].parse::<u8>() {
+                  return Ok(message::InputReadingV4::new(
+                    device_index,
+                    feature_index,
+                    InputTypeReading::Battery(InputValue::new(level)),
+                  ));
+                }
+              }
+            }
+            Ok(HardwareEvent::Disconnected(_)) | Err(_) => {
+              return Err(ButtplugDeviceError::ProtocolSpecificError(
+                "Lovense".to_owned(),
+                "Lovense Device disconnected while getting Battery info.".to_owned(),
               ));
             }
           }
         }
-        HardwareEvent::Disconnected(_) => {
+        _ = async_manager::sleep(Duration::from_millis(LOVENSE_COMMAND_TIMEOUT_MS)).fuse() => {
+          warn!("Lovense Device timed out while getting Battery info.");
           return Err(ButtplugDeviceError::ProtocolSpecificError(
             "Lovense".to_owned(),
-            "Lovense Device disconnected while getting Battery info.".to_owned(),
+            "Lovense Device timed out while getting Battery info.".to_owned(),
           ));
         }
       }
     }
-    Err(ButtplugDeviceError::ProtocolSpecificError(
-      "Lovense".to_owned(),
-      "Lovense Device disconnected while getting Battery info.".to_owned(),
-    ))
   }
   .boxed()
 }

--- a/crates/buttplug_server/src/device/protocol_impl/lovense/mod.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/lovense/mod.rs
@@ -36,7 +36,7 @@ use buttplug_server_device_config::{
   UserDeviceIdentifier,
 };
 use futures::{FutureExt, future::BoxFuture};
-use regex::Regex;
+use regex_lite::Regex;
 use std::{sync::Arc, time::Duration};
 use tokio::select;
 use uuid::{Uuid, uuid};

--- a/crates/buttplug_server/src/device/protocol_impl/vibcrafter.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/vibcrafter.rs
@@ -33,7 +33,7 @@ use uuid::{Uuid, uuid};
 
 use rand::RngExt;
 use rand::distr::Alphanumeric;
-use regex::Regex;
+use regex_lite::Regex;
 use sha2::{Digest, Sha256};
 
 type Aes128EcbEnc = ecb::Encryptor<Aes128>;

--- a/crates/buttplug_server/src/device/server_device_manager_event_loop.rs
+++ b/crates/buttplug_server/src/device/server_device_manager_event_loop.rs
@@ -5,7 +5,10 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use buttplug_core::message::{ButtplugMessage, ButtplugServerMessageV4, DeviceListV4, ScanningFinishedV0};
+use buttplug_core::{
+  errors::ButtplugError,
+  message::{ButtplugMessage, ButtplugServerMessageV4, DeviceListV4, ErrorV0, ScanningFinishedV0},
+};
 use buttplug_server_device_config::DeviceConfigurationManager;
 use tracing::info_span;
 
@@ -280,6 +283,7 @@ impl ServerDeviceManagerEventLoop {
         }
 
         let device_event_sender_clone = self.device_event_sender.clone();
+        let server_sender_clone = self.server_sender.clone();
 
         let device_config_manager = self.device_config_manager.clone();
         let connecting_devices = self.connecting_devices.clone();
@@ -315,6 +319,13 @@ impl ServerDeviceManagerEventLoop {
               }
               Err(e) => {
                 error!("Device errored while trying to connect: {:?}", e);
+                let error_msg = ErrorV0::from(ButtplugError::from(e));
+                if server_sender_clone
+                  .send(ButtplugServerMessageV4::Error(error_msg))
+                  .is_err()
+                {
+                  error!("Server disappeared before device error could be sent.");
+                }
               }
             }
             connecting_devices.remove(&address);

--- a/crates/buttplug_server_device_config/src/device_config_file/device.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/device.rs
@@ -31,14 +31,23 @@ pub struct ConfigBaseDeviceDefinition {
 }
 
 impl ConfigBaseDeviceDefinition {
-  pub fn update_with_configuration(&self, config: ConfigBaseDeviceDefinition) -> Self {
+  /// Consume `self` (a device-specific config) and fill any unset optional fields from
+  /// `defaults` (the protocol-level defaults). `self` always wins; defaults are only used where
+  /// `self` has `None`.
+  pub fn with_defaults(self, defaults: Option<&ConfigBaseDeviceDefinition>) -> Self {
     Self {
-      identifier: config.identifier().clone(),
-      name: config.name().clone(),
-      id: config.id(),
-      protocol_variant: config.protocol_variant.or(self.protocol_variant.clone()),
-      message_gap_ms: config.message_gap_ms.or(self.message_gap_ms),
-      features: config.features.or(self.features.clone()),
+      identifier: self.identifier,
+      name: self.name,
+      id: self.id,
+      protocol_variant: self
+        .protocol_variant
+        .or_else(|| defaults.and_then(|d| d.protocol_variant.clone())),
+      message_gap_ms: self
+        .message_gap_ms
+        .or_else(|| defaults.and_then(|d| d.message_gap_ms)),
+      features: self
+        .features
+        .or_else(|| defaults.and_then(|d| d.features.clone())),
     }
   }
 }

--- a/crates/buttplug_server_device_config/src/device_config_file/feature.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/feature.rs
@@ -265,12 +265,12 @@ impl From<ConfigBaseDeviceFeature> for ServerDeviceFeature {
   fn from(val: ConfigBaseDeviceFeature) -> Self {
     ServerDeviceFeature::new(
       val.index,
-      &val.description,
+      val.description,
       val.id,
       None,
       val.feature_settings.alt_protocol_index,
-      &val.output,
-      &val.input,
+      val.output,
+      val.input,
     )
   }
 }
@@ -304,12 +304,12 @@ impl ConfigUserDeviceFeature {
       .collect::<Result<SmallVecEnumMap<ServerDeviceFeatureOutput, 1>, _>>()?;
     Ok(ServerDeviceFeature::new(
       base_feature.index(),
-      &base_feature.description,
+      base_feature.description.clone(),
       self.id,
       Some(self.base_id),
       base_feature.alt_protocol_index,
-      &output,
-      &base_feature.input,
+      output,
+      base_feature.input.clone(),
     ))
   }
 }

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -127,12 +127,10 @@ fn load_main_config(
       if let Some(idents) = config.identifier() {
         for config_ident in idents {
           let ident = BaseDeviceIdentifier::new_with_identifier(&protocol_name, config_ident);
-          if let Some(d) = &default {
-            dcm_builder
-              .base_device_definition(&ident, &d.update_with_configuration(config.clone()).into());
-          } else {
-            dcm_builder.base_device_definition(&ident, &config.clone().into());
-          }
+          dcm_builder.base_device_definition(
+            &ident,
+            &config.clone().with_defaults(default.as_ref()).into(),
+          );
         }
       }
     }

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -18,7 +18,7 @@ use crate::device_config_file::{
   user::{UserConfigDefinition, UserConfigFile, UserDeviceConfigPair},
 };
 
-use super::{BaseDeviceIdentifier, DeviceConfigurationManager, DeviceConfigurationManagerBuilder};
+use super::{BaseDeviceIdentifier, DeviceConfigurationManager, DeviceConfigurationManagerBuilder, ServerDeviceDefinition};
 use buttplug_core::{
   errors::{ButtplugDeviceError, ButtplugError},
   util::json::JSONValidator,
@@ -26,7 +26,7 @@ use buttplug_core::{
 use dashmap::DashMap;
 use getset::CopyGetters;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::{fmt::Display, sync::Arc};
 
 pub static DEVICE_CONFIGURATION_JSON: &str =
   include_str!("../../build-config/buttplug-device-config-v4.json");
@@ -119,18 +119,17 @@ fn load_main_config(
       default = Some(features.clone());
       dcm_builder.base_device_definition(
         &BaseDeviceIdentifier::new_default(&protocol_name),
-        &features.clone().into(),
+        Arc::new(ServerDeviceDefinition::from(features.clone())),
       );
     }
 
     for config in protocol_def.configurations() {
       if let Some(idents) = config.identifier() {
+        let definition: Arc<ServerDeviceDefinition> =
+          Arc::new(config.clone().with_defaults(default.as_ref()).into());
         for config_ident in idents {
           let ident = BaseDeviceIdentifier::new_with_identifier(&protocol_name, config_ident);
-          dcm_builder.base_device_definition(
-            &ident,
-            &config.clone().with_defaults(default.as_ref()).into(),
-          );
+          dcm_builder.base_device_definition(&ident, definition.clone());
         }
       }
     }
@@ -170,7 +169,7 @@ fn load_user_config(
       if let Some(idents) = config.identifier() {
         for config_ident in idents {
           let ident = BaseDeviceIdentifier::new_with_identifier(&protocol_name, config_ident);
-          dcm_builder.base_device_definition(&ident, &config.clone().into());
+          dcm_builder.base_device_definition(&ident, Arc::new(config.clone().into()));
         }
       }
     }

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -11,6 +11,7 @@ use getset::Getters;
 use std::{
   collections::HashMap,
   fmt::{self, Debug},
+  sync::Arc,
 };
 use uuid::Uuid;
 
@@ -27,7 +28,7 @@ use crate::{
 pub struct DeviceConfigurationManagerBuilder {
   base_communication_specifiers: HashMap<String, Vec<ProtocolCommunicationSpecifier>>,
   user_communication_specifiers: DashMap<String, Vec<ProtocolCommunicationSpecifier>>,
-  base_device_definitions: HashMap<BaseDeviceIdentifier, ServerDeviceDefinition>,
+  base_device_definitions: HashMap<BaseDeviceIdentifier, Arc<ServerDeviceDefinition>>,
   user_device_definitions: DashMap<UserDeviceIdentifier, ServerDeviceDefinition>,
 }
 
@@ -48,11 +49,11 @@ impl DeviceConfigurationManagerBuilder {
   pub fn base_device_definition(
     &mut self,
     identifier: &BaseDeviceIdentifier,
-    features: &ServerDeviceDefinition,
+    definition: Arc<ServerDeviceDefinition>,
   ) -> &mut Self {
     self
       .base_device_definitions
-      .insert(identifier.clone(), features.clone());
+      .insert(identifier.clone(), definition);
     self
   }
 
@@ -139,7 +140,8 @@ pub struct DeviceConfigurationManager {
   #[getset(get = "pub")]
   base_communication_specifiers: HashMap<String, Vec<ProtocolCommunicationSpecifier>>,
   /// Device definitions from the base device config. Should not change/update during a session.
-  base_device_definitions: HashMap<BaseDeviceIdentifier, ServerDeviceDefinition>,
+  #[getset(get = "pub")]
+  base_device_definitions: HashMap<BaseDeviceIdentifier, Arc<ServerDeviceDefinition>>,
   /// Communication specifiers provided by the user, mapped from protocol name to vector of
   /// specifiers. Loaded at session start, may change over life of session.
   #[getset(get = "pub")]
@@ -167,6 +169,27 @@ impl Default for DeviceConfigurationManager {
 }
 
 impl DeviceConfigurationManager {
+  /// Construct a `DeviceConfigurationManager` directly from pre-built maps, bypassing the
+  /// builder and its validation logic.
+  ///
+  /// **Use with caution**: the builder (`DeviceConfigurationManagerBuilder::finish`) performs
+  /// validation and reconciliation steps that this constructor skips. Prefer the builder for
+  /// any config loaded from JSON. This path exists for embedded or test contexts that assemble
+  /// their own protocol/identifier maps and cannot or do not want to go through the JSON config
+  /// pipeline. If you find yourself calling this in non-embedded production code, that is
+  /// probably a sign the builder API needs extension rather than a bypass.
+  pub fn new(
+    base_communication_specifiers: HashMap<String, Vec<ProtocolCommunicationSpecifier>>,
+    base_device_definitions: HashMap<BaseDeviceIdentifier, Arc<ServerDeviceDefinition>>,
+  ) -> Self {
+    Self {
+      base_communication_specifiers,
+      user_communication_specifiers: DashMap::new(),
+      base_device_definitions,
+      user_device_definitions: DashMap::new(),
+    }
+  }
+
   pub fn add_user_communication_specifier(
     &self,
     protocol: &str,

--- a/crates/buttplug_server_device_config/src/device_definitions.rs
+++ b/crates/buttplug_server_device_config/src/device_definitions.rs
@@ -8,10 +8,11 @@
 use std::collections::BTreeMap;
 
 use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use super::server_device_feature::ServerDeviceFeature;
-#[derive(Debug, Clone, Getters, CopyGetters)]
+#[derive(Debug, Clone, Getters, CopyGetters, Serialize, Deserialize)]
 pub struct ServerDeviceDefinition {
   #[getset(get = "pub")]
   /// Given name of the device this instance represents.

--- a/crates/buttplug_server_device_config/src/endpoint.rs
+++ b/crates/buttplug_server_device_config/src/endpoint.rs
@@ -29,7 +29,8 @@ use core::hash::Hash;
 /// context. These names are used in [Device Configuration](crate::server::device::configuration)
 /// and the [Device Configuration File](crate::util::device_configuration), and are expected to
 /// de/serialize to lowercase versions of their names.
-#[derive(EnumString, Clone, Debug, PartialEq, Eq, Hash, Display, Copy)]
+#[repr(u8)]
+#[derive(EnumString, Clone, Debug, PartialEq, Eq, Hash, Display, Copy, FromRepr)]
 #[strum(serialize_all = "lowercase")]
 pub enum Endpoint {
   /// Expect to take commands, when multiple receive endpoints may be available
@@ -133,13 +134,17 @@ impl Serialize for Endpoint {
   where
     S: Serializer,
   {
-    serializer.serialize_str(&self.to_string())
+    if serializer.is_human_readable() {
+      serializer.serialize_str(&self.to_string())
+    } else {
+      serializer.serialize_u8(*self as u8)
+    }
   }
 }
 
-struct EndpointVisitor;
+struct EndpointStrVisitor;
 
-impl Visitor<'_> for EndpointVisitor {
+impl Visitor<'_> for EndpointStrVisitor {
   type Value = Endpoint;
 
   fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -159,6 +164,12 @@ impl<'de> Deserialize<'de> for Endpoint {
   where
     D: Deserializer<'de>,
   {
-    deserializer.deserialize_str(EndpointVisitor)
+    if deserializer.is_human_readable() {
+      Ok(deserializer.deserialize_str(EndpointStrVisitor)?)
+    } else {
+      let value = u8::deserialize(deserializer)?;
+      Endpoint::from_repr(value)
+        .ok_or_else(|| de::Error::custom(format!("invalid endpoint value: {value}")))
+    }
   }
 }

--- a/crates/buttplug_server_device_config/src/identifiers.rs
+++ b/crates/buttplug_server_device_config/src/identifiers.rs
@@ -42,7 +42,7 @@ impl UserDeviceIdentifier {
 
 /// Set of information used for matching devices to their features and related communication protocol.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Getters, MutGetters, Serialize, Deserialize)]
-#[getset(get = "pub(crate)", get_mut = "pub(crate)")]
+#[getset(get = "pub", get_mut = "pub(crate)")]
 pub struct BaseDeviceIdentifier {
   /// Name of the protocol this device uses to communicate
   protocol: String,

--- a/crates/buttplug_server_device_config/src/server_device_feature.rs
+++ b/crates/buttplug_server_device_config/src/server_device_feature.rs
@@ -543,21 +543,21 @@ impl Default for ServerDeviceFeature {
 impl ServerDeviceFeature {
   pub fn new(
     index: u32,
-    description: &str,
+    description: String,
     id: Uuid,
     base_id: Option<Uuid>,
     alt_protocol_index: Option<u32>,
-    output: &SmallVecEnumMap<ServerDeviceFeatureOutput, 1>,
-    input: &SmallVecEnumMap<ServerDeviceFeatureInput, 1>,
+    output: SmallVecEnumMap<ServerDeviceFeatureOutput, 1>,
+    input: SmallVecEnumMap<ServerDeviceFeatureInput, 1>,
   ) -> Self {
     Self {
       index,
-      description: description.to_owned(),
+      description,
       id,
       base_id,
       alt_protocol_index,
-      output: output.clone(),
-      input: input.clone(),
+      output,
+      input,
     }
   }
 

--- a/crates/buttplug_server_device_config/src/server_device_feature.rs
+++ b/crates/buttplug_server_device_config/src/server_device_feature.rs
@@ -113,7 +113,7 @@ impl RangeWithLimit {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerDeviceFeatureOutputValueProperties {
   pub value: RangeWithLimit,
-  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default)]
   pub disabled: bool,
 }
 
@@ -159,9 +159,9 @@ impl From<&ServerDeviceFeatureOutputValueProperties> for DeviceFeatureOutputValu
 #[derive(Debug, Clone, Getters, CopyGetters, Serialize, Deserialize)]
 pub struct ServerDeviceFeatureOutputPositionProperties {
   pub value: RangeWithLimit,
-  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default)]
   pub disabled: bool,
-  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default)]
   pub reverse_position: bool,
 }
 
@@ -212,9 +212,9 @@ impl From<&ServerDeviceFeatureOutputPositionProperties> for DeviceFeatureOutputV
 pub struct ServerDeviceFeatureOutputHwPositionWithDurationProperties {
   pub value: RangeWithLimit,
   pub duration: RangeWithLimit,
-  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default)]
   pub disabled: bool,
-  #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+  #[serde(default)]
   pub reverse_position: bool,
 }
 
@@ -500,20 +500,20 @@ impl_input_type_conversions![Battery, Rssi, Button, Pressure, Depth, Position,];
 #[serde(default)]
 pub struct ServerDeviceFeature {
   #[getset(get_copy = "pub")]
-  #[serde(skip)]
+  #[serde(default)]
   index: u32,
   #[serde(default)]
   pub description: String,
   #[serde(skip)]
   #[getset(get_copy = "pub")]
   id: Uuid,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default)]
   pub base_id: Option<Uuid>,
-  #[serde(skip_serializing_if = "Option::is_none")]
+  #[serde(default)]
   pub alt_protocol_index: Option<u32>,
-  #[serde(skip_serializing_if = "SmallVecEnumMap::is_empty", default)]
+  #[serde(default)]
   pub output: SmallVecEnumMap<ServerDeviceFeatureOutput, 1>,
-  #[serde(skip_serializing_if = "SmallVecEnumMap::is_empty", default)]
+  #[serde(default)]
   pub input: SmallVecEnumMap<ServerDeviceFeatureInput, 1>,
 }
 

--- a/crates/buttplug_server_hwmgr_btleplug/src/btleplug_hardware.rs
+++ b/crates/buttplug_server_hwmgr_btleplug/src/btleplug_hardware.rs
@@ -324,7 +324,15 @@ impl<T: Peripheral + 'static> HardwareInternal for BtlePlugHardware<T> {
   fn disconnect(&self) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
     let device = self.device.clone();
     async move {
-      let _ = device.disconnect().await;
+      // Check is_connected first: calling peripheral.disconnect() on an
+      // already-disconnected device can hang indefinitely waiting for a
+      // D-Bus reply that will never arrive (the device is already gone).
+      let connected = device.is_connected().await.unwrap_or(false);
+      if connected {
+        // Still add a timeout in case the device disconnects *between*
+        // the is_connected check and the disconnect call.
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), device.disconnect()).await;
+      }
       Ok(())
     }
     .boxed()


### PR DESCRIPTION
## Summary

This PR is a grouped set of changes that makes buttplug significantly more embedded-ready in practice, while also improving stability and runtime portability for general upstream users.

High-level goals:

1. Fix reliability issues that can lead to hangs or missing error propagation.
2. Improve runtime compatibility and dependency footprint.
3. Reduce avoidable cloning in device config loading.
4. Prepare config types for postcard-compatible binary serialization.

This PR, together with already merged PRs https://github.com/buttplugio/buttplug/pull/839 and https://github.com/buttplugio/buttplug/pull/852, is intended to replace https://github.com/buttplugio/buttplug/pull/833 with a cleaner, better-scoped set of changes.

It also makes buttplug work well for my use-case in https://github.com/jsmnbom/esp-butt, with only minor downstream fork deltas still needed:

- a disconnect_device() method on ServerDeviceManager
- rework of error serialization to avoid serde-json entirely

## What Changed

### Reliability Fixes

- btleplug: prevent disconnect hangs by guarding disconnect with is_connected and timeout
- server: forward device connection errors back to the client
- lovense: add timeout in battery query path via select
- device_task: switch batch deadline sleep to runtime abstraction

### Runtime Portability and Dependency Footprint

- buttplug_server: swap regex to regex-lite

### Device Config Quality and Clone Reduction

- rename update_with_configuration to with_defaults and simplify call sites
- store base device definitions as Arc to avoid repeated cloning
- make ServerDeviceFeature::new take owned values so clone points are explicit
- derive Debug and Clone for ClientDeviceOutputCommand

### Postcard-Compatible Serialization Groundwork

- Endpoint: human-readable string serde plus compact binary serde representation
- ServerDeviceDefinition: derive Serialize and Deserialize
- BaseDeviceIdentifier: expose getters publicly for external inspection of returned identifiers
- ServerDeviceFeature: remove conditional field omission where binary round-trip requires field presence

## Why This Replaces PR #833

Compared to https://github.com/buttplugio/buttplug/pull/833, this series is split into smaller, logical commits and is easier to review and validate incrementally.

It also aligns the upstream story around postcard-compatible serde support rather than embedded-only changes, while keeping the fork-only items isolated.

## Scope and Non-Goals

Included:

- stability fixes, runtime portability updates, device config cleanup, and postcard-compatibility groundwork

Not included:

- fork-only items that are still downstream-only:
  - disconnect_device() method on ServerDeviceManager
  - error serialization rework to avoid serde-json entirely

## Validation

- built affected crates during each step
- ran full test suite:
  - cargo test
  - result: pass (no failures)

## Commit Groups

Reliability fixes:

- ff3d1b94 btleplug: guard disconnect() against hang on already-disconnected devices
- b38bc0d4 server: forward device connection errors to the client
- 8dc2a764 device_task: use async_manager::sleep for batch deadline
- 9e3b0975 lovense: add timeout to handle_battery_level_cmd via select!

Runtime portability and dependency footprint:

- 025c8376 buttplug_server: swap regex -> regex-lite

Device config cleanup and clone reduction:

- 5bdfe46d device_config: rename update_with_configuration -> with_defaults
- e0d8d8df device_config: store base_device_definitions as Arc<ServerDeviceDefinition>
- 44f25611 device_config: make ServerDeviceFeature::new take owned values
- 2704c6c6 buttplug_client: derive Debug and Clone for ClientDeviceOutputCommand

Postcard-compatible serialization groundwork:

- 4d47572b device_config: add binary serde support for Endpoint
- b83f890b device_config: derive serde for ServerDeviceDefinition
- 3c62e18b device_config: make BaseDeviceIdentifier getters public
- d3815d85 device_config: make ServerDeviceFeature binary-serde friendly

## Follow-up Needed

We still need a proper memory-focused test pass similar to concerns raised in https://github.com/buttplugio/buttplug/pull/833.