### PR TITLE
feat: add simulated device hardware manager and output observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ DeviceHandle → ServerDeviceManager → ButtplugServer::output_observation_stre
 Each observation carries `device_index`, `feature_index`, `output_type`, and `value`. Disabled by default to avoid overhead; enable via `ServerDeviceManagerBuilder::emit_output_observations(true)` or `EngineOptions::emit_output_observations`.
 
 **Simulated Devices** (no-hardware testing):
-Simulated devices allow testing the full device lifecycle without real hardware. Configuration lives in the user config under `simulated_devices`, each entry referencing an archetype from `simulated.yml` (5 archetypes: single-vibe, dual-vibe, rotate, linear, multi-feature). Key contracts:
+Simulated devices allow testing the full device lifecycle without real hardware. Configuration lives in the user config under `simulated_devices`, each entry referencing an archetype from `simulated.yml` (5 archetypes: simulated-1vibe, simulated-2vibe, simulated-rotator, simulated-oscillator, simulated-stroker). Key contracts:
 - `SimulatedSpecifier` variant on `ProtocolCommunicationSpecifier` -- matches devices by archetype name
 - `SimulatedDeviceConfigEntry` in `UserConfigDefinition` -- identifier (archetype name), optional display_name, auto-generated UUID address
 - `DeviceConfigurationManager::available_simulated_archetypes()` -- lists valid archetypes with feature summaries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Last verified: 2026-05-17
+Last verified: 2026-05-19
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -43,6 +43,7 @@ Buttplug is a framework for interfacing with intimate hardware devices. It uses 
 - `lovense_dongle`, `lovense_connect` - Lovense-specific (deprecated)
 - `xinput` - Windows gamepad vibration
 - `websocket` - WebSocket device forwarders
+- `simulated` - In-process simulated devices (no real hardware; lives in `buttplug_server`)
 
 **Infrastructure:**
 - `buttplug_server_device_config` - Device configuration database
@@ -81,6 +82,15 @@ DeviceHandle → ServerDeviceManager → ButtplugServer::output_observation_stre
              → Frontend (as EngineMessage::DeviceOutputObservation)
 ```
 Each observation carries `device_index`, `feature_index`, `output_type`, and `value`. Disabled by default to avoid overhead; enable via `ServerDeviceManagerBuilder::emit_output_observations(true)` or `EngineOptions::emit_output_observations`.
+
+**Simulated Devices** (no-hardware testing):
+Simulated devices allow testing the full device lifecycle without real hardware. Configuration lives in the user config under `simulated_devices`, each entry referencing an archetype from `simulated.yml` (5 archetypes: single-vibe, dual-vibe, rotate, linear, multi-feature). Key contracts:
+- `SimulatedSpecifier` variant on `ProtocolCommunicationSpecifier` -- matches devices by archetype name
+- `SimulatedDeviceConfigEntry` in `UserConfigDefinition` -- identifier (archetype name), optional display_name, auto-generated UUID address
+- `DeviceConfigurationManager::available_simulated_archetypes()` -- lists valid archetypes with feature summaries
+- `ServerDeviceManagerBuilder::finish()` auto-wires `SimulatedHardwareCommunicationManager` when simulated_devices is non-empty
+- Validation rejects unknown archetypes and duplicate addresses at config build time
+- `SimulatedProtocol` is a no-op handler; `SimulatedHardwareConnector` creates in-memory endpoints
 
 ## Contributing
 

--- a/crates/buttplug_core/src/util/mod.rs
+++ b/crates/buttplug_core/src/util/mod.rs
@@ -17,5 +17,5 @@ pub mod serializers;
 
 #[cfg(all(not(feature = "wasm"), feature = "tokio-runtime"))]
 pub use tokio::time::sleep;
-#[cfg(all(feature = "wasm", feature = "tokio-runtime"))]
+#[cfg(feature = "wasm")]
 pub use wasmtimer::tokio::sleep;

--- a/crates/buttplug_core/src/util/mod.rs
+++ b/crates/buttplug_core/src/util/mod.rs
@@ -15,7 +15,7 @@ pub mod stream;
 pub mod small_vec_enum_map;
 pub mod serializers;
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(all(not(feature = "wasm"), feature = "tokio-runtime"))]
 pub use tokio::time::sleep;
-#[cfg(feature = "wasm")]
+#[cfg(all(feature = "wasm", feature = "tokio-runtime"))]
 pub use wasmtimer::tokio::sleep;

--- a/crates/buttplug_server/src/device/device_handle.rs
+++ b/crates/buttplug_server/src/device/device_handle.rs
@@ -278,7 +278,7 @@ impl DeviceHandle {
       // OutputType derives Display via strum, producing clean names like "Vibrate", "Rotate".
       // The design uses format!("{:?}") but to_string() is preferred for clean output.
       let _ = sender.send(OutputObservation {
-        device_index: msg.device_index(),
+        device_index: self.definition.index(),
         feature_index: msg.feature_index(),
         output_type: msg.output_command().as_output_type().to_string(),
         value: msg.output_command().value() as f64,

--- a/crates/buttplug_server/src/device/hardware/mod.rs
+++ b/crates/buttplug_server/src/device/hardware/mod.rs
@@ -6,6 +6,7 @@
 // for full license information.
 
 pub mod communication;
+pub mod simulated;
 use std::{collections::HashSet, fmt::Debug, sync::Arc, time::Duration};
 
 use async_trait::async_trait;

--- a/crates/buttplug_server/src/device/hardware/simulated.rs
+++ b/crates/buttplug_server/src/device/hardware/simulated.rs
@@ -334,7 +334,7 @@ mod tests {
   fn test_simulated_hardware_connector_specifier() {
     let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
     let hardware = SimulatedHardwareInternal::new("test-address");
-    let connector = SimulatedHardwareConnector::new(specifier.clone(), hardware);
+    let connector = SimulatedHardwareConnector::new(specifier.clone(), hardware, "test-id".to_string());
 
     assert_eq!(connector.specifier(), specifier);
   }
@@ -343,7 +343,7 @@ mod tests {
   async fn test_simulated_hardware_connector_connect() {
     let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
     let hardware = SimulatedHardwareInternal::new("test-address");
-    let mut connector = SimulatedHardwareConnector::new(specifier, hardware);
+    let mut connector = SimulatedHardwareConnector::new(specifier, hardware, "test-id".to_string());
 
     let result = connector.connect().await;
     assert!(result.is_ok());
@@ -353,7 +353,7 @@ mod tests {
   async fn test_simulated_hardware_specializer_specialize() {
     let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
     let hardware = SimulatedHardwareInternal::new("test-address");
-    let mut connector = SimulatedHardwareConnector::new(specifier.clone(), hardware);
+    let mut connector = SimulatedHardwareConnector::new(specifier.clone(), hardware, "test-id".to_string());
 
     let mut specializer = connector.connect().await.unwrap();
     let result = specializer.specialize(&[specifier]).await;

--- a/crates/buttplug_server/src/device/hardware/simulated.rs
+++ b/crates/buttplug_server/src/device/hardware/simulated.rs
@@ -1,0 +1,469 @@
+// Buttplug Rust Source Code File - See https://buttplug.io for more info.
+//
+// Copyright 2016-2026 Nonpolynomial Labs LLC. All rights reserved.
+//
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root
+// for full license information.
+
+use crate::device::hardware::{
+  Hardware, HardwareConnector, HardwareEvent, HardwareInternal, HardwareReadCmd, HardwareReading,
+  HardwareSpecializer, HardwareSubscribeCmd, HardwareUnsubscribeCmd, HardwareWriteCmd,
+};
+use crate::device::hardware::communication::{
+  HardwareCommunicationManager, HardwareCommunicationManagerBuilder,
+  HardwareCommunicationManagerEvent,
+};
+use async_trait::async_trait;
+use buttplug_core::errors::ButtplugDeviceError;
+use buttplug_core::ButtplugResultFuture;
+use buttplug_server_device_config::{Endpoint, ProtocolCommunicationSpecifier, SimulatedSpecifier};
+use futures::future::{self, BoxFuture, FutureExt};
+use std::fmt::{self, Debug};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc::Sender;
+use tracing::error;
+
+pub struct SimulatedHardwareInternal {
+  address: String,
+  event_sender: broadcast::Sender<HardwareEvent>,
+}
+
+impl SimulatedHardwareInternal {
+  pub fn new(address: &str) -> Self {
+    let (event_sender, _) = broadcast::channel(256);
+    Self {
+      address: address.to_owned(),
+      event_sender,
+    }
+  }
+}
+
+impl HardwareInternal for SimulatedHardwareInternal {
+  fn event_stream(&self) -> broadcast::Receiver<HardwareEvent> {
+    self.event_sender.subscribe()
+  }
+
+  fn disconnect(&self) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    let sender = self.event_sender.clone();
+    let address = self.address.clone();
+    async move {
+      let _ = sender.send(HardwareEvent::Disconnected(address));
+      Ok(())
+    }
+    .boxed()
+  }
+
+  fn read_value(
+    &self,
+    msg: &HardwareReadCmd,
+  ) -> BoxFuture<'static, Result<HardwareReading, ButtplugDeviceError>> {
+    let endpoint = msg.endpoint();
+    future::ready(Ok(HardwareReading::new(endpoint, &[]))).boxed()
+  }
+
+  fn write_value(
+    &self,
+    _msg: &HardwareWriteCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Ok(())).boxed()
+  }
+
+  fn subscribe(
+    &self,
+    _msg: &HardwareSubscribeCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Ok(())).boxed()
+  }
+
+  fn unsubscribe(
+    &self,
+    _msg: &HardwareUnsubscribeCmd,
+  ) -> BoxFuture<'static, Result<(), ButtplugDeviceError>> {
+    future::ready(Ok(())).boxed()
+  }
+}
+
+pub struct SimulatedHardwareConnector {
+  specifier: ProtocolCommunicationSpecifier,
+  hardware: Option<SimulatedHardwareInternal>,
+}
+
+impl SimulatedHardwareConnector {
+  pub fn new(specifier: ProtocolCommunicationSpecifier, hardware: SimulatedHardwareInternal) -> Self {
+    Self {
+      specifier,
+      hardware: Some(hardware),
+    }
+  }
+}
+
+impl Debug for SimulatedHardwareConnector {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("SimulatedHardwareConnector")
+      .field("specifier", &self.specifier)
+      .finish()
+  }
+}
+
+#[async_trait]
+impl HardwareConnector for SimulatedHardwareConnector {
+  fn specifier(&self) -> ProtocolCommunicationSpecifier {
+    self.specifier.clone()
+  }
+
+  async fn connect(&mut self) -> Result<Box<dyn HardwareSpecializer>, ButtplugDeviceError> {
+    Ok(Box::new(SimulatedHardwareSpecializer {
+      hardware: self.hardware.take(),
+    }))
+  }
+}
+
+pub struct SimulatedHardwareSpecializer {
+  hardware: Option<SimulatedHardwareInternal>,
+}
+
+#[async_trait]
+impl HardwareSpecializer for SimulatedHardwareSpecializer {
+  async fn specialize(
+    &mut self,
+    _specifiers: &[ProtocolCommunicationSpecifier],
+  ) -> Result<Hardware, ButtplugDeviceError> {
+    let device = self
+      .hardware
+      .take()
+      .ok_or(ButtplugDeviceError::DeviceConnectionError(
+        "Simulated hardware already taken".to_owned(),
+      ))?;
+    let address = device.address.clone();
+    let endpoints = vec![Endpoint::Tx];
+    Ok(Hardware::new(
+      "Simulated Device",
+      &address,
+      &endpoints,
+      &None,
+      false,
+      Box::new(device),
+    ))
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct SimulatedDeviceEntry {
+  pub identifier: String,
+  pub display_name: Option<String>,
+  pub address: String,
+}
+
+pub struct SimulatedHardwareCommunicationManagerBuilder {
+  devices: Vec<SimulatedDeviceEntry>,
+}
+
+impl SimulatedHardwareCommunicationManagerBuilder {
+  pub fn new(devices: Vec<SimulatedDeviceEntry>) -> Self {
+    Self { devices }
+  }
+}
+
+impl HardwareCommunicationManagerBuilder for SimulatedHardwareCommunicationManagerBuilder {
+  fn finish(
+    &mut self,
+    sender: Sender<HardwareCommunicationManagerEvent>,
+  ) -> Box<dyn HardwareCommunicationManager> {
+    let devices = std::mem::take(&mut self.devices);
+    Box::new(SimulatedHardwareCommunicationManager::new(sender, devices))
+  }
+}
+
+pub struct SimulatedHardwareCommunicationManager {
+  device_sender: Sender<HardwareCommunicationManagerEvent>,
+  devices: Vec<SimulatedDeviceEntry>,
+  is_scanning: Arc<AtomicBool>,
+}
+
+impl SimulatedHardwareCommunicationManager {
+  fn new(
+    device_sender: Sender<HardwareCommunicationManagerEvent>,
+    devices: Vec<SimulatedDeviceEntry>,
+  ) -> Self {
+    Self {
+      device_sender,
+      devices,
+      is_scanning: Arc::new(AtomicBool::new(false)),
+    }
+  }
+}
+
+impl HardwareCommunicationManager for SimulatedHardwareCommunicationManager {
+  fn name(&self) -> &'static str {
+    "SimulatedHardwareCommunicationManager"
+  }
+
+  fn start_scanning(&mut self) -> ButtplugResultFuture {
+    let mut events = vec![];
+
+    for device in &self.devices {
+      let name = device
+        .display_name
+        .as_deref()
+        .unwrap_or(&device.identifier);
+      let specifier = ProtocolCommunicationSpecifier::Simulated(
+        SimulatedSpecifier::new(&device.identifier),
+      );
+      let hardware = SimulatedHardwareInternal::new(&device.address);
+      let connector = SimulatedHardwareConnector::new(specifier, hardware);
+
+      events.push(HardwareCommunicationManagerEvent::DeviceFound {
+        name: name.to_owned(),
+        address: device.address.clone(),
+        creator: Box::new(connector),
+      });
+    }
+
+    let device_sender = self.device_sender.clone();
+    let is_scanning = self.is_scanning.clone();
+    async move {
+      is_scanning.store(true, Ordering::Relaxed);
+      for event in events {
+        if device_sender.send(event).await.is_err() {
+          error!("Simulated device channel no longer open.");
+        }
+      }
+      is_scanning.store(false, Ordering::Relaxed);
+      if device_sender
+        .send(HardwareCommunicationManagerEvent::ScanningFinished)
+        .await
+        .is_err()
+      {
+        error!("Error sending scanning finished for simulated devices.");
+      }
+      Ok(())
+    }
+    .boxed()
+  }
+
+  fn stop_scanning(&mut self) -> ButtplugResultFuture {
+    future::ready(Ok(())).boxed()
+  }
+
+  fn can_scan(&self) -> bool {
+    !self.devices.is_empty()
+  }
+
+  fn scanning_status(&self) -> bool {
+    self.is_scanning.load(Ordering::Relaxed)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_simulated_hardware_internal_new() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    assert_eq!(hardware.address, "test-address");
+  }
+
+  #[test]
+  fn test_simulated_hardware_internal_event_stream() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let _receiver = hardware.event_stream();
+    // Just verify it doesn't panic
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_internal_write_value() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let uuid = uuid::Uuid::new_v4();
+    let cmd = HardwareWriteCmd::new(&[uuid], Endpoint::Tx, vec![1, 2, 3], false);
+    let result = hardware.write_value(&cmd).await;
+    assert!(result.is_ok());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_internal_read_value() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let cmd = HardwareReadCmd::new(uuid::Uuid::new_v4(), Endpoint::Tx, 10, 1000);
+    let result = hardware.read_value(&cmd).await;
+    assert!(result.is_ok());
+    let reading = result.unwrap();
+    assert_eq!(reading.data().len(), 0);
+    assert_eq!(*reading.endpoint(), Endpoint::Tx);
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_internal_subscribe() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let cmd = HardwareSubscribeCmd::new(uuid::Uuid::new_v4(), Endpoint::Tx);
+    let result = hardware.subscribe(&cmd).await;
+    assert!(result.is_ok());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_internal_unsubscribe() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let cmd = HardwareUnsubscribeCmd::new(uuid::Uuid::new_v4(), Endpoint::Tx);
+    let result = hardware.unsubscribe(&cmd).await;
+    assert!(result.is_ok());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_internal_disconnect() {
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let mut receiver = hardware.event_stream();
+
+    let disconnect_result = hardware.disconnect().await;
+    assert!(disconnect_result.is_ok());
+
+    // Check that disconnect event was sent
+    let event = receiver.recv().await;
+    assert!(event.is_ok());
+    match event.unwrap() {
+      HardwareEvent::Disconnected(addr) => assert_eq!(addr, "test-address"),
+      _ => panic!("Expected Disconnected event"),
+    }
+  }
+
+  #[test]
+  fn test_simulated_hardware_connector_specifier() {
+    let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let connector = SimulatedHardwareConnector::new(specifier.clone(), hardware);
+
+    assert_eq!(connector.specifier(), specifier);
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_connector_connect() {
+    let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let mut connector = SimulatedHardwareConnector::new(specifier, hardware);
+
+    let result = connector.connect().await;
+    assert!(result.is_ok());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_specializer_specialize() {
+    let specifier = ProtocolCommunicationSpecifier::Simulated(SimulatedSpecifier::new("test-id"));
+    let hardware = SimulatedHardwareInternal::new("test-address");
+    let mut connector = SimulatedHardwareConnector::new(specifier.clone(), hardware);
+
+    let mut specializer = connector.connect().await.unwrap();
+    let result = specializer.specialize(&[specifier]).await;
+
+    assert!(result.is_ok());
+    let hw = result.unwrap();
+    assert_eq!(hw.address(), "test-address");
+    assert_eq!(hw.endpoints().len(), 1);
+    assert_eq!(hw.endpoints()[0], Endpoint::Tx);
+  }
+
+  #[test]
+  fn test_simulated_hardware_communication_manager_builder() {
+    let devices = vec![
+      SimulatedDeviceEntry {
+        identifier: "device1".to_string(),
+        display_name: Some("Test Device 1".to_string()),
+        address: "addr1".to_string(),
+      },
+    ];
+    let builder = SimulatedHardwareCommunicationManagerBuilder::new(devices);
+    assert_eq!(builder.devices.len(), 1);
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_communication_manager_can_scan_with_devices() {
+    let devices = vec![
+      SimulatedDeviceEntry {
+        identifier: "device1".to_string(),
+        display_name: Some("Test Device 1".to_string()),
+        address: "addr1".to_string(),
+      },
+    ];
+    let (tx, _rx) = tokio::sync::mpsc::channel(10);
+    let manager = SimulatedHardwareCommunicationManager::new(tx, devices);
+
+    assert!(manager.can_scan());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_communication_manager_can_scan_without_devices() {
+    let devices = vec![];
+    let (tx, _rx) = tokio::sync::mpsc::channel(10);
+    let manager = SimulatedHardwareCommunicationManager::new(tx, devices);
+
+    assert!(!manager.can_scan());
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_communication_manager_start_scanning() {
+    let devices = vec![
+      SimulatedDeviceEntry {
+        identifier: "device1".to_string(),
+        display_name: Some("Test Device 1".to_string()),
+        address: "addr1".to_string(),
+      },
+      SimulatedDeviceEntry {
+        identifier: "device2".to_string(),
+        display_name: None,
+        address: "addr2".to_string(),
+      },
+    ];
+    let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+    let mut manager = SimulatedHardwareCommunicationManager::new(tx, devices);
+
+    let scan_result = manager.start_scanning().await;
+    assert!(scan_result.is_ok());
+
+    // Should receive DeviceFound events
+    let event1 = rx.recv().await;
+    assert!(event1.is_some());
+    match event1.unwrap() {
+      HardwareCommunicationManagerEvent::DeviceFound { name, address, .. } => {
+        assert_eq!(name, "Test Device 1");
+        assert_eq!(address, "addr1");
+      }
+      _ => panic!("Expected DeviceFound event"),
+    }
+
+    let event2 = rx.recv().await;
+    assert!(event2.is_some());
+    match event2.unwrap() {
+      HardwareCommunicationManagerEvent::DeviceFound { name, address, .. } => {
+        assert_eq!(name, "device2");
+        assert_eq!(address, "addr2");
+      }
+      _ => panic!("Expected DeviceFound event"),
+    }
+
+    // Should receive ScanningFinished event
+    let event3 = rx.recv().await;
+    assert!(event3.is_some());
+    match event3.unwrap() {
+      HardwareCommunicationManagerEvent::ScanningFinished => {}
+      _ => panic!("Expected ScanningFinished event"),
+    }
+  }
+
+  #[tokio::test]
+  async fn test_simulated_hardware_communication_manager_stop_scanning() {
+    let devices = vec![];
+    let (tx, _rx) = tokio::sync::mpsc::channel(10);
+    let mut manager = SimulatedHardwareCommunicationManager::new(tx, devices);
+
+    let result = manager.stop_scanning().await;
+    assert!(result.is_ok());
+  }
+
+  #[test]
+  fn test_simulated_hardware_communication_manager_name() {
+    let devices = vec![];
+    let (tx, _rx) = tokio::sync::mpsc::channel(10);
+    let manager = SimulatedHardwareCommunicationManager::new(tx, devices);
+
+    assert_eq!(manager.name(), "SimulatedHardwareCommunicationManager");
+  }
+}

--- a/crates/buttplug_server/src/device/hardware/simulated.rs
+++ b/crates/buttplug_server/src/device/hardware/simulated.rs
@@ -88,13 +88,15 @@ impl HardwareInternal for SimulatedHardwareInternal {
 pub struct SimulatedHardwareConnector {
   specifier: ProtocolCommunicationSpecifier,
   hardware: Option<SimulatedHardwareInternal>,
+  identifier: String,
 }
 
 impl SimulatedHardwareConnector {
-  pub fn new(specifier: ProtocolCommunicationSpecifier, hardware: SimulatedHardwareInternal) -> Self {
+  pub fn new(specifier: ProtocolCommunicationSpecifier, hardware: SimulatedHardwareInternal, identifier: String) -> Self {
     Self {
       specifier,
       hardware: Some(hardware),
+      identifier,
     }
   }
 }
@@ -116,12 +118,14 @@ impl HardwareConnector for SimulatedHardwareConnector {
   async fn connect(&mut self) -> Result<Box<dyn HardwareSpecializer>, ButtplugDeviceError> {
     Ok(Box::new(SimulatedHardwareSpecializer {
       hardware: self.hardware.take(),
+      identifier: self.identifier.clone(),
     }))
   }
 }
 
 pub struct SimulatedHardwareSpecializer {
   hardware: Option<SimulatedHardwareInternal>,
+  identifier: String,
 }
 
 #[async_trait]
@@ -139,7 +143,7 @@ impl HardwareSpecializer for SimulatedHardwareSpecializer {
     let address = device.address.clone();
     let endpoints = vec![Endpoint::Tx];
     Ok(Hardware::new(
-      "Simulated Device",
+      &self.identifier,
       &address,
       &endpoints,
       &None,
@@ -212,7 +216,7 @@ impl HardwareCommunicationManager for SimulatedHardwareCommunicationManager {
         SimulatedSpecifier::new(&device.identifier),
       );
       let hardware = SimulatedHardwareInternal::new(&device.address);
-      let connector = SimulatedHardwareConnector::new(specifier, hardware);
+      let connector = SimulatedHardwareConnector::new(specifier, hardware, device.identifier.clone());
 
       events.push(HardwareCommunicationManagerEvent::DeviceFound {
         name: name.to_owned(),

--- a/crates/buttplug_server/src/device/protocol_impl/mod.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/mod.rs
@@ -104,6 +104,7 @@ pub mod sexverse_v2;
 pub mod sexverse_v3;
 pub mod sexverse_v4;
 pub mod sexverse_v5;
+pub mod simulated;
 pub mod svakom;
 pub mod synchro;
 pub mod tcode_v03;
@@ -440,6 +441,10 @@ pub fn get_default_protocol_map() -> HashMap<String, Arc<dyn ProtocolIdentifierF
   add_to_protocol_map(
     &mut map,
     sexverse_v5::setup::SexverseV5IdentifierFactory::default(),
+  );
+  add_to_protocol_map(
+    &mut map,
+    simulated::setup::SimulatedProtocolIdentifierFactory::default(),
   );
   add_to_protocol_map(&mut map, serveu::setup::ServeUIdentifierFactory::default());
   add_to_protocol_map(

--- a/crates/buttplug_server/src/device/protocol_impl/simulated.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/simulated.rs
@@ -1,0 +1,15 @@
+// Buttplug Rust Source Code File - See https://buttplug.io for more info.
+//
+// Copyright 2016-2026 Nonpolynomial Labs LLC. All rights reserved.
+//
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root
+// for full license information.
+
+use crate::device::protocol::{ProtocolHandler, generic_protocol_setup};
+
+generic_protocol_setup!(SimulatedProtocol, "simulated");
+
+#[derive(Default)]
+pub struct SimulatedProtocol {}
+
+impl ProtocolHandler for SimulatedProtocol {}

--- a/crates/buttplug_server/src/device/protocol_impl/simulated.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/simulated.rs
@@ -6,10 +6,95 @@
 // for full license information.
 
 use crate::device::protocol::{ProtocolHandler, generic_protocol_setup};
+use buttplug_core::errors::ButtplugDeviceError;
+use crate::device::hardware::HardwareCommand;
+use uuid::Uuid;
 
 generic_protocol_setup!(SimulatedProtocol, "simulated");
 
 #[derive(Default)]
 pub struct SimulatedProtocol {}
 
-impl ProtocolHandler for SimulatedProtocol {}
+impl ProtocolHandler for SimulatedProtocol {
+  fn handle_output_vibrate_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _speed: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_rotate_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _speed: i32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_oscillate_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _speed: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_position_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _value: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_constrict_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _speed: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_spray_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _speed: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_temperature_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _level: i32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_output_led_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _color: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+
+  fn handle_hw_position_with_duration_cmd(
+    &self,
+    _feature_index: u32,
+    _feature_id: Uuid,
+    _value: u32,
+    _duration: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    Ok(vec![])
+  }
+}

--- a/crates/buttplug_server/src/device/server_device_manager.rs
+++ b/crates/buttplug_server/src/device/server_device_manager.rs
@@ -108,7 +108,27 @@ impl ServerDeviceManagerBuilder {
     self
   }
 
+  pub fn add_simulated_devices_if_configured(&mut self) -> &mut Self {
+    let simulated_devices = self.device_configuration_manager.simulated_devices();
+    if !simulated_devices.is_empty() {
+      use crate::device::hardware::simulated::{
+        SimulatedDeviceEntry, SimulatedHardwareCommunicationManagerBuilder,
+      };
+      let entries: Vec<SimulatedDeviceEntry> = simulated_devices
+        .iter()
+        .map(|config| SimulatedDeviceEntry {
+          identifier: config.identifier().clone(),
+          display_name: config.display_name().clone(),
+          address: config.address().clone(),
+        })
+        .collect();
+      self.comm_manager(SimulatedHardwareCommunicationManagerBuilder::new(entries));
+    }
+    self
+  }
+
   pub fn finish(&mut self) -> Result<ServerDeviceManager, ButtplugServerError> {
+    self.add_simulated_devices_if_configured();
     let (device_command_sender, device_command_receiver) = mpsc::channel(256);
     let (device_event_sender, device_event_receiver) = mpsc::channel(256);
     let mut comm_managers: Vec<Box<dyn HardwareCommunicationManager>> = Vec::new();

--- a/crates/buttplug_server/src/device/server_device_manager.rs
+++ b/crates/buttplug_server/src/device/server_device_manager.rs
@@ -128,7 +128,6 @@ impl ServerDeviceManagerBuilder {
   }
 
   pub fn finish(&mut self) -> Result<ServerDeviceManager, ButtplugServerError> {
-    self.add_simulated_devices_if_configured();
     let (device_command_sender, device_command_receiver) = mpsc::channel(256);
     let (device_event_sender, device_event_receiver) = mpsc::channel(256);
     let mut comm_managers: Vec<Box<dyn HardwareCommunicationManager>> = Vec::new();

--- a/crates/buttplug_server_device_config/Cargo.toml
+++ b/crates/buttplug_server_device_config/Cargo.toml
@@ -19,7 +19,7 @@ doctest = true
 doc = true
 
 [dependencies]
-buttplug_core = { version = "10.0.2", path = "../buttplug_core", default-features = false, features = ["tokio-runtime"] }
+buttplug_core = { version = "10.0.2", path = "../buttplug_core", default-features = false }
 futures = "0.3.32"
 futures-util = "0.3.32"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/buttplug_server_device_config/Cargo.toml
+++ b/crates/buttplug_server_device_config/Cargo.toml
@@ -19,7 +19,7 @@ doctest = true
 doc = true
 
 [dependencies]
-buttplug_core = { version = "10.0.2", path = "../buttplug_core", default-features = false }
+buttplug_core = { version = "10.0.2", path = "../buttplug_core", default-features = false, features = ["tokio-runtime"] }
 futures = "0.3.32"
 futures-util = "0.3.32"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
+++ b/crates/buttplug_server_device_config/build-config/buttplug-device-config-v4.json
@@ -1,7 +1,7 @@
 {
   "version": {
     "major": 4,
-    "minor": 198
+    "minor": 199
   },
   "protocols": {
     "activejoy": {
@@ -20372,6 +20372,175 @@
         ],
         "id": "783bc287-528c-4c58-a7ec-47a49304309e",
         "name": "Sexverse Heart"
+      }
+    },
+    "simulated": {
+      "communication": [
+        {
+          "simulated": {
+            "names": [
+              "simulated-1vibe",
+              "simulated-2vibe",
+              "simulated-rotator",
+              "simulated-oscillator",
+              "simulated-stroker"
+            ]
+          }
+        }
+      ],
+      "configurations": [
+        {
+          "features": [
+            {
+              "description": "Motor",
+              "id": "a1b2c3d4-1001-4000-8000-000000000001",
+              "index": 0,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "a1b2c3d4-1000-4000-8000-000000000000",
+          "identifier": [
+            "simulated-1vibe"
+          ],
+          "name": "Simulated 1-Motor Vibrator"
+        },
+        {
+          "features": [
+            {
+              "description": "Motor 1",
+              "id": "a1b2c3d4-2001-4000-8000-000000000001",
+              "index": 0,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            },
+            {
+              "description": "Motor 2",
+              "id": "a1b2c3d4-2002-4000-8000-000000000002",
+              "index": 1,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "a1b2c3d4-2000-4000-8000-000000000000",
+          "identifier": [
+            "simulated-2vibe"
+          ],
+          "name": "Simulated 2-Motor Vibrator"
+        },
+        {
+          "features": [
+            {
+              "description": "Rotation Motor",
+              "id": "a1b2c3d4-3001-4000-8000-000000000001",
+              "index": 0,
+              "output": {
+                "rotate": {
+                  "value": [
+                    -100,
+                    100
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "a1b2c3d4-3000-4000-8000-000000000000",
+          "identifier": [
+            "simulated-rotator"
+          ],
+          "name": "Simulated Rotator"
+        },
+        {
+          "features": [
+            {
+              "description": "Oscillation Motor",
+              "id": "a1b2c3d4-4001-4000-8000-000000000001",
+              "index": 0,
+              "output": {
+                "oscillate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "a1b2c3d4-4000-4000-8000-000000000000",
+          "identifier": [
+            "simulated-oscillator"
+          ],
+          "name": "Simulated Oscillator"
+        },
+        {
+          "features": [
+            {
+              "description": "Linear Axis",
+              "id": "a1b2c3d4-5001-4000-8000-000000000001",
+              "index": 0,
+              "output": {
+                "hw_position_with_duration": {
+                  "duration": [
+                    0,
+                    100000
+                  ],
+                  "value": [
+                    0,
+                    1000
+                  ]
+                },
+                "position": {
+                  "value": [
+                    0,
+                    1000
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "a1b2c3d4-5000-4000-8000-000000000000",
+          "identifier": [
+            "simulated-stroker"
+          ],
+          "name": "Simulated Stroker"
+        }
+      ],
+      "defaults": {
+        "features": [
+          {
+            "description": "Motor",
+            "id": "a1b2c3d4-0001-4000-8000-000000000001",
+            "index": 0,
+            "output": {
+              "vibrate": {
+                "value": [
+                  0,
+                  100
+                ]
+              }
+            }
+          }
+        ],
+        "id": "a1b2c3d4-0000-4000-8000-000000000000",
+        "name": "Simulated Device"
       }
     },
     "svakom-alex": {

--- a/crates/buttplug_server_device_config/device-config-v4/protocols/simulated.yml
+++ b/crates/buttplug_server_device_config/device-config-v4/protocols/simulated.yml
@@ -1,0 +1,102 @@
+---
+defaults:
+  name: Simulated Device
+  features:
+  - description: Motor
+    id: a1b2c3d4-0001-4000-8000-000000000001
+    output:
+      vibrate:
+        value:
+        - 0
+        - 100
+    index: 0
+  id: a1b2c3d4-0000-4000-8000-000000000000
+configurations:
+- identifier:
+  - simulated-1vibe
+  name: Simulated 1-Motor Vibrator
+  features:
+  - description: Motor
+    id: a1b2c3d4-1001-4000-8000-000000000001
+    output:
+      vibrate:
+        value:
+        - 0
+        - 100
+    index: 0
+  id: a1b2c3d4-1000-4000-8000-000000000000
+- identifier:
+  - simulated-2vibe
+  name: Simulated 2-Motor Vibrator
+  features:
+  - description: Motor 1
+    id: a1b2c3d4-2001-4000-8000-000000000001
+    output:
+      vibrate:
+        value:
+        - 0
+        - 100
+    index: 0
+  - description: Motor 2
+    id: a1b2c3d4-2002-4000-8000-000000000002
+    output:
+      vibrate:
+        value:
+        - 0
+        - 100
+    index: 1
+  id: a1b2c3d4-2000-4000-8000-000000000000
+- identifier:
+  - simulated-rotator
+  name: Simulated Rotator
+  features:
+  - description: Rotation Motor
+    id: a1b2c3d4-3001-4000-8000-000000000001
+    output:
+      rotate:
+        value:
+        - -100
+        - 100
+    index: 0
+  id: a1b2c3d4-3000-4000-8000-000000000000
+- identifier:
+  - simulated-oscillator
+  name: Simulated Oscillator
+  features:
+  - description: Oscillation Motor
+    id: a1b2c3d4-4001-4000-8000-000000000001
+    output:
+      oscillate:
+        value:
+        - 0
+        - 100
+    index: 0
+  id: a1b2c3d4-4000-4000-8000-000000000000
+- identifier:
+  - simulated-stroker
+  name: Simulated Stroker
+  features:
+  - description: Linear Axis
+    id: a1b2c3d4-5001-4000-8000-000000000001
+    output:
+      position:
+        value:
+        - 0
+        - 1000
+      hw_position_with_duration:
+        value:
+        - 0
+        - 1000
+        duration:
+        - 0
+        - 100000
+    index: 0
+  id: a1b2c3d4-5000-4000-8000-000000000000
+communication:
+- simulated:
+    names:
+    - simulated-1vibe
+    - simulated-2vibe
+    - simulated-rotator
+    - simulated-oscillator
+    - simulated-stroker

--- a/crates/buttplug_server_device_config/device-config-v4/version.yaml
+++ b/crates/buttplug_server_device_config/device-config-v4/version.yaml
@@ -1,3 +1,3 @@
 version:
   major: 4
-  minor: 198
+  minor: 199

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -260,10 +260,15 @@ pub fn save_user_config(dcm: &DeviceConfigurationManager) -> Result<String, Butt
       },
     );
   }
+  let simulated_devices = if dcm.simulated_devices().is_empty() {
+    None
+  } else {
+    Some(dcm.simulated_devices().clone())
+  };
   let user_config_definition = UserConfigDefinition {
     protocols: Some(user_protos.clone()),
     user_device_configs: Some(user_definitions_vec),
-    simulated_devices: None,
+    simulated_devices,
   };
   let mut user_config_file = UserConfigFile::new(4, 0);
   user_config_file.set_user_configs(Some(user_config_definition));

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -11,7 +11,7 @@ mod feature;
 mod protocol;
 mod user;
 
-pub use user::SimulatedDeviceConfigEntry;
+pub use user::{SimulatedDeviceConfigEntry, SimulatedDeviceArchetype, SimulatedDeviceFeatureSummary};
 
 use base::BaseConfigFile;
 

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -11,6 +11,8 @@ mod feature;
 mod protocol;
 mod user;
 
+pub use user::SimulatedDeviceConfigEntry;
+
 use base::BaseConfigFile;
 
 use crate::device_config_file::{
@@ -257,6 +259,7 @@ pub fn save_user_config(dcm: &DeviceConfigurationManager) -> Result<String, Butt
   let user_config_definition = UserConfigDefinition {
     protocols: Some(user_protos.clone()),
     user_device_configs: Some(user_definitions_vec),
+    simulated_devices: None,
   };
   let mut user_config_file = UserConfigFile::new(4, 0);
   user_config_file.set_user_configs(Some(user_config_definition));

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -211,6 +211,10 @@ fn load_user_config(
     }
   }
 
+  if let Some(simulated_devices) = user_config.simulated_devices().clone() {
+    dcm_builder.simulated_devices(simulated_devices);
+  }
+
   Ok(())
 }
 

--- a/crates/buttplug_server_device_config/src/device_config_file/mod.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/mod.rs
@@ -260,10 +260,11 @@ pub fn save_user_config(dcm: &DeviceConfigurationManager) -> Result<String, Butt
       },
     );
   }
-  let simulated_devices = if dcm.simulated_devices().is_empty() {
+  let simulated_devices = dcm.simulated_devices();
+  let simulated_devices = if simulated_devices.is_empty() {
     None
   } else {
-    Some(dcm.simulated_devices().clone())
+    Some(simulated_devices)
   };
   let user_config_definition = UserConfigDefinition {
     protocols: Some(user_protos.clone()),

--- a/crates/buttplug_server_device_config/src/device_config_file/user.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/user.rs
@@ -116,3 +116,119 @@ impl UserConfigFile {
       .expect("All types below this are Serialize, so this should be infallible.")
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::load_protocol_configs;
+
+  #[test]
+  fn test_simulated_device_config_roundtrip() {
+    // AC1.2, AC5.2: Create a UserConfigFile with simulated_devices entries,
+    // serialize to JSON, deserialize back, verify fields match
+    let mut config = UserConfigDefinition::default();
+    config.simulated_devices = Some(vec![
+      SimulatedDeviceConfigEntry::new("simulated-1vibe", None),
+      SimulatedDeviceConfigEntry::new("simulated-2vibe", Some("My Custom 2-Vibe".to_string())),
+    ]);
+
+    let user_config_file = UserConfigFile {
+      version: get_internal_config_version(),
+      user_configs: Some(config),
+    };
+
+    // Serialize to JSON
+    let json_str = user_config_file.to_json();
+
+    // Deserialize back
+    let deserialized: UserConfigFile = serde_json::from_str(&json_str)
+      .expect("Roundtrip should work");
+
+    // Verify fields match
+    let user_cfg = deserialized.user_configs().clone().expect("Should have user_configs");
+    let devices = user_cfg.simulated_devices.as_ref()
+      .expect("Should have simulated_devices");
+
+    assert_eq!(devices.len(), 2);
+    assert_eq!(devices[0].identifier, "simulated-1vibe");
+    assert_eq!(devices[0].display_name, None);
+    assert!(devices[0].address.starts_with("simulated:"));
+
+    assert_eq!(devices[1].identifier, "simulated-2vibe");
+    assert_eq!(devices[1].display_name, Some("My Custom 2-Vibe".to_string()));
+    assert!(devices[1].address.starts_with("simulated:"));
+  }
+
+  #[test]
+  fn test_simulated_device_address_auto_generation() {
+    // AC5.3: Address should auto-generate with simulated: prefix and UUID
+    let entry = SimulatedDeviceConfigEntry::new("simulated-1vibe", None);
+
+    assert!(entry.address.starts_with("simulated:"));
+    assert!(entry.address.len() > "simulated:".len());
+  }
+
+  #[test]
+  fn test_simulated_device_display_name_optional() {
+    // AC5.4: Display name can be omitted from JSON when None
+    let entry_with_display_name = SimulatedDeviceConfigEntry::new("simulated-1vibe", Some("My Device".to_string()));
+    let entry_without_display_name = SimulatedDeviceConfigEntry::new("simulated-1vibe", None);
+
+    let json_with = serde_json::to_value(&entry_with_display_name).unwrap();
+    let json_without = serde_json::to_value(&entry_without_display_name).unwrap();
+
+    // Entry with display_name should have the field in JSON
+    assert!(json_with.get("display_name").is_some());
+
+    // Entry without display_name should NOT have the field in JSON (skip_serializing_if = "Option::is_none")
+    assert!(json_without.get("display_name").is_none());
+  }
+
+  #[test]
+  fn test_invalid_archetype_rejected() {
+    // AC8.1: Invalid archetype identifier should produce error at config load time
+    let mut builder = load_protocol_configs(&None, &None, false)
+      .expect("Should load base configs");
+
+    // Add an invalid simulated device entry
+    let invalid_entry = SimulatedDeviceConfigEntry::new("nonexistent-device", None);
+    builder.add_simulated_devices(vec![invalid_entry]);
+
+    // Attempt to finish should error because the archetype doesn't exist
+    let result = builder.finish();
+    assert!(
+      result.is_err(),
+      "Should reject nonexistent archetype at config load time"
+    );
+  }
+
+  #[test]
+  fn test_duplicate_address_rejected() {
+    // AC8.2: Duplicate addresses should be rejected
+    let mut builder = load_protocol_configs(&None, &None, false)
+      .expect("Should load base configs");
+
+    // Create two devices with the same explicit address
+    let addr = "simulated:duplicate-test".to_string();
+    let device1 = SimulatedDeviceConfigEntry {
+      identifier: "simulated-1vibe".to_string(),
+      display_name: None,
+      address: addr.clone(),
+    };
+    let device2 = SimulatedDeviceConfigEntry {
+      identifier: "simulated-1vibe".to_string(),
+      display_name: Some("Duplicate".to_string()),
+      address: addr.clone(),
+    };
+
+    builder.add_simulated_devices(vec![device1, device2]);
+
+    // Should error on duplicate address
+    let result = builder.finish();
+    assert!(
+      result.is_err(),
+      "Should reject duplicate addresses"
+    );
+  }
+}
+

--- a/crates/buttplug_server_device_config/src/device_config_file/user.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/user.rs
@@ -8,6 +8,7 @@
 use dashmap::DashMap;
 use getset::{Getters, MutGetters, Setters};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::UserDeviceIdentifier;
 
@@ -26,6 +27,30 @@ pub struct UserDeviceConfigPair {
   pub config: ConfigUserDeviceDefinition,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, Getters, Setters, MutGetters)]
+#[getset(get = "pub", set = "pub", get_mut = "pub(crate)")]
+pub struct SimulatedDeviceConfigEntry {
+  pub identifier: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub display_name: Option<String>,
+  #[serde(default = "SimulatedDeviceConfigEntry::generate_address")]
+  pub address: String,
+}
+
+impl SimulatedDeviceConfigEntry {
+  pub fn new(identifier: &str, display_name: Option<String>) -> Self {
+    Self {
+      identifier: identifier.to_owned(),
+      display_name,
+      address: Self::generate_address(),
+    }
+  }
+
+  fn generate_address() -> String {
+    format!("simulated:{}", Uuid::new_v4())
+  }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, Default, Getters, Setters, MutGetters)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct UserConfigDefinition {
@@ -33,6 +58,8 @@ pub struct UserConfigDefinition {
   pub protocols: Option<DashMap<String, ProtocolDefinition>>,
   #[serde(rename = "devices", default, skip_serializing_if = "Option::is_none")]
   pub user_device_configs: Option<Vec<UserDeviceConfigPair>>,
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub simulated_devices: Option<Vec<SimulatedDeviceConfigEntry>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Getters, Setters)]

--- a/crates/buttplug_server_device_config/src/device_config_file/user.rs
+++ b/crates/buttplug_server_device_config/src/device_config_file/user.rs
@@ -51,6 +51,20 @@ impl SimulatedDeviceConfigEntry {
   }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatedDeviceArchetype {
+  pub identifier: String,
+  pub display_name: String,
+  pub output_features: Vec<SimulatedDeviceFeatureSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimulatedDeviceFeatureSummary {
+  pub description: String,
+  pub output_type: String,
+  pub index: u32,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, Default, Getters, Setters, MutGetters)]
 #[getset(get = "pub", set = "pub", get_mut = "pub")]
 pub struct UserConfigDefinition {

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -118,6 +118,41 @@ impl DeviceConfigurationManagerBuilder {
       user_attribute_tree_map.insert(kv.key().clone(), kv.value().clone());
     }
 
+    // Validate simulated devices
+    if !self.simulated_devices.is_empty() {
+      let valid_archetypes: std::collections::HashSet<String> = self
+        .base_communication_specifiers
+        .get("simulated")
+        .into_iter()
+        .flat_map(|specifiers| specifiers.iter())
+        .filter_map(|spec| {
+          if let ProtocolCommunicationSpecifier::Simulated(sim) = spec {
+            Some(sim.names().iter().cloned())
+          } else {
+            None
+          }
+        })
+        .flatten()
+        .collect();
+
+      let mut seen_addresses = std::collections::HashSet::new();
+      for device in &self.simulated_devices {
+        if !valid_archetypes.contains(&device.identifier) {
+          return Err(ButtplugDeviceError::DeviceConfigurationError(format!(
+            "Invalid simulated device archetype '{}'. Valid archetypes: {:?}",
+            device.identifier,
+            valid_archetypes
+          )));
+        }
+        if !seen_addresses.insert(&device.address) {
+          return Err(ButtplugDeviceError::DeviceConfigurationError(format!(
+            "Duplicate simulated device address '{}' for archetype '{}'",
+            device.address, device.identifier
+          )));
+        }
+      }
+    }
+
     Ok(DeviceConfigurationManager {
       base_communication_specifiers: self.base_communication_specifiers.clone(),
       user_communication_specifiers: self.user_communication_specifiers.clone(),

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -22,6 +22,7 @@ use crate::{
   ServerDeviceDefinition,
   ServerDeviceDefinitionBuilder,
   UserDeviceIdentifier,
+  SimulatedDeviceConfigEntry,
 };
 
 #[derive(Default, Clone)]
@@ -30,6 +31,7 @@ pub struct DeviceConfigurationManagerBuilder {
   user_communication_specifiers: DashMap<String, Vec<ProtocolCommunicationSpecifier>>,
   base_device_definitions: HashMap<BaseDeviceIdentifier, Arc<ServerDeviceDefinition>>,
   user_device_definitions: DashMap<UserDeviceIdentifier, ServerDeviceDefinition>,
+  simulated_devices: Vec<SimulatedDeviceConfigEntry>,
 }
 
 impl DeviceConfigurationManagerBuilder {
@@ -96,6 +98,11 @@ impl DeviceConfigurationManagerBuilder {
     }
   }
 
+  pub fn simulated_devices(&mut self, devices: Vec<SimulatedDeviceConfigEntry>) -> &mut Self {
+    self.simulated_devices = devices;
+    self
+  }
+
   pub fn finish(&mut self) -> Result<DeviceConfigurationManager, ButtplugDeviceError> {
     // Build and validate the protocol attributes tree.
     let mut attribute_tree_map = HashMap::new();
@@ -116,6 +123,7 @@ impl DeviceConfigurationManagerBuilder {
       user_communication_specifiers: self.user_communication_specifiers.clone(),
       base_device_definitions: attribute_tree_map,
       user_device_definitions: user_attribute_tree_map,
+      simulated_devices: self.simulated_devices.clone(),
       //protocol_map,
     })
   }
@@ -150,6 +158,9 @@ pub struct DeviceConfigurationManager {
   /// of session.
   #[getset(get = "pub")]
   user_device_definitions: DashMap<UserDeviceIdentifier, ServerDeviceDefinition>,
+  /// Simulated device configurations from the user config.
+  #[getset(get = "pub")]
+  simulated_devices: Vec<SimulatedDeviceConfigEntry>,
 }
 
 impl Debug for DeviceConfigurationManager {
@@ -187,6 +198,7 @@ impl DeviceConfigurationManager {
       user_communication_specifiers: DashMap::new(),
       base_device_definitions,
       user_device_definitions: DashMap::new(),
+      simulated_devices: Vec::new(),
     }
   }
 

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -104,6 +104,11 @@ impl DeviceConfigurationManagerBuilder {
     self
   }
 
+  pub fn add_simulated_devices(&mut self, devices: Vec<SimulatedDeviceConfigEntry>) -> &mut Self {
+    self.simulated_devices.extend(devices);
+    self
+  }
+
   pub fn finish(&mut self) -> Result<DeviceConfigurationManager, ButtplugDeviceError> {
     // Build and validate the protocol attributes tree.
     let mut attribute_tree_map = HashMap::new();

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -364,7 +364,9 @@ impl DeviceConfigurationManager {
         identifier
       );
       let mut builder = ServerDeviceDefinitionBuilder::from_base(definition, Uuid::new_v4(), true);
-      builder.index(self.device_index(identifier)).finish()
+      builder.index(self.device_index(identifier));
+      self.apply_simulated_display_name(&mut builder, identifier);
+      builder.finish()
     } else if let Some(definition) = self
       .base_device_definitions
       .get(&BaseDeviceIdentifier::new(identifier.protocol(), &None))
@@ -374,7 +376,9 @@ impl DeviceConfigurationManager {
         identifier
       );
       let mut builder = ServerDeviceDefinitionBuilder::from_base(definition, Uuid::new_v4(), true);
-      builder.index(self.device_index(identifier)).finish()
+      builder.index(self.device_index(identifier));
+      self.apply_simulated_display_name(&mut builder, identifier);
+      builder.finish()
     } else {
       return None;
     };
@@ -391,6 +395,20 @@ impl DeviceConfigurationManager {
     }
 
     Some(features)
+  }
+
+  fn apply_simulated_display_name(
+    &self,
+    builder: &mut ServerDeviceDefinitionBuilder,
+    identifier: &UserDeviceIdentifier,
+  ) {
+    if let Some(entry) = self
+      .simulated_devices
+      .iter()
+      .find(|d| d.address() == identifier.address())
+    {
+      builder.display_name(entry.display_name());
+    }
   }
 
   pub fn available_simulated_archetypes(&self) -> Vec<SimulatedDeviceArchetype> {

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -12,6 +12,7 @@ use std::{
   collections::HashMap,
   fmt::{self, Debug},
   sync::Arc,
+  sync::RwLock,
 };
 use uuid::Uuid;
 
@@ -21,8 +22,8 @@ use crate::{
   ProtocolCommunicationSpecifier,
   ServerDeviceDefinition,
   ServerDeviceDefinitionBuilder,
-  UserDeviceIdentifier,
   SimulatedDeviceConfigEntry,
+  UserDeviceIdentifier,
   device_config_file::{SimulatedDeviceArchetype, SimulatedDeviceFeatureSummary},
 };
 
@@ -164,7 +165,7 @@ impl DeviceConfigurationManagerBuilder {
       user_communication_specifiers: self.user_communication_specifiers.clone(),
       base_device_definitions: attribute_tree_map,
       user_device_definitions: user_attribute_tree_map,
-      simulated_devices: self.simulated_devices.clone(),
+      simulated_devices_store: RwLock::new(self.simulated_devices.clone()),
       //protocol_map,
     })
   }
@@ -200,8 +201,7 @@ pub struct DeviceConfigurationManager {
   #[getset(get = "pub")]
   user_device_definitions: DashMap<UserDeviceIdentifier, ServerDeviceDefinition>,
   /// Simulated device configurations from the user config.
-  #[getset(get = "pub")]
-  simulated_devices: Vec<SimulatedDeviceConfigEntry>,
+  simulated_devices_store: RwLock<Vec<SimulatedDeviceConfigEntry>>,
 }
 
 impl Debug for DeviceConfigurationManager {
@@ -239,8 +239,74 @@ impl DeviceConfigurationManager {
       user_communication_specifiers: DashMap::new(),
       base_device_definitions,
       user_device_definitions: DashMap::new(),
-      simulated_devices: Vec::new(),
+      simulated_devices_store: RwLock::new(Vec::new()),
     }
+  }
+
+  pub fn simulated_devices(&self) -> Vec<SimulatedDeviceConfigEntry> {
+    self
+      .simulated_devices_store
+      .read()
+      .expect("Simulated device config lock should not be poisoned")
+      .clone()
+  }
+
+  fn valid_simulated_archetypes(&self) -> std::collections::HashSet<String> {
+    self
+      .base_communication_specifiers
+      .get("simulated")
+      .into_iter()
+      .flat_map(|specifiers| specifiers.iter())
+      .filter_map(|spec| {
+        if let ProtocolCommunicationSpecifier::Simulated(sim) = spec {
+          Some(sim.names().iter().cloned())
+        } else {
+          None
+        }
+      })
+      .flatten()
+      .collect()
+  }
+
+  pub fn add_simulated_device(
+    &self,
+    device: SimulatedDeviceConfigEntry,
+  ) -> Result<(), ButtplugDeviceError> {
+    let valid_archetypes = self.valid_simulated_archetypes();
+    if !valid_archetypes.contains(&device.identifier) {
+      return Err(ButtplugDeviceError::DeviceConfigurationError(format!(
+        "Invalid simulated device archetype '{}'. Valid archetypes: {:?}",
+        device.identifier, valid_archetypes
+      )));
+    }
+
+    let mut simulated_devices = self
+      .simulated_devices_store
+      .write()
+      .expect("Simulated device config lock should not be poisoned");
+    if simulated_devices
+      .iter()
+      .any(|existing| existing.address == device.address)
+    {
+      return Err(ButtplugDeviceError::DeviceConfigurationError(format!(
+        "Duplicate simulated device address '{}' for archetype '{}'",
+        device.address, device.identifier
+      )));
+    }
+
+    simulated_devices.push(device);
+    Ok(())
+  }
+
+  pub fn remove_simulated_device(&self, address: &str) {
+    let mut simulated_devices = self
+      .simulated_devices_store
+      .write()
+      .expect("Simulated device config lock should not be poisoned");
+    simulated_devices.retain(|device| device.address != address);
+    self.user_device_definitions.retain(|identifier, _| {
+      identifier.protocol() != "simulated" || identifier.address() != address
+    });
   }
 
   pub fn add_user_communication_specifier(
@@ -403,7 +469,9 @@ impl DeviceConfigurationManager {
     identifier: &UserDeviceIdentifier,
   ) {
     if let Some(entry) = self
-      .simulated_devices
+      .simulated_devices_store
+      .read()
+      .expect("Simulated device config lock should not be poisoned")
       .iter()
       .find(|d| d.address() == identifier.address())
     {
@@ -447,5 +515,62 @@ impl DeviceConfigurationManager {
         }
       })
       .collect()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::load_protocol_configs;
+
+  #[test]
+  fn test_add_simulated_device_validates_archetype_and_address() {
+    let dcm = load_protocol_configs(&None, &None, false)
+      .expect("Should load base configs")
+      .finish()
+      .expect("Should build DCM");
+
+    let entry = SimulatedDeviceConfigEntry::new("simulated-1vibe", None);
+    let duplicate = entry.clone();
+
+    dcm
+      .add_simulated_device(entry)
+      .expect("Valid simulated archetype should add");
+    assert_eq!(dcm.simulated_devices().len(), 1);
+
+    let duplicate_result = dcm.add_simulated_device(duplicate);
+    assert!(duplicate_result.is_err());
+
+    let invalid_result = dcm.add_simulated_device(SimulatedDeviceConfigEntry::new(
+      "not-a-simulated-device",
+      None,
+    ));
+    assert!(invalid_result.is_err());
+  }
+
+  #[test]
+  fn test_remove_simulated_device_removes_matching_user_definition() {
+    let dcm = load_protocol_configs(&None, &None, false)
+      .expect("Should load base configs")
+      .finish()
+      .expect("Should build DCM");
+
+    let entry = SimulatedDeviceConfigEntry::new("simulated-1vibe", None);
+    let address = entry.address.clone();
+    let identifier =
+      UserDeviceIdentifier::new(&address, "simulated", &Some(entry.identifier.clone()));
+
+    dcm
+      .add_simulated_device(entry)
+      .expect("Valid simulated archetype should add");
+    dcm
+      .device_definition(&identifier)
+      .expect("Simulated device definition should resolve");
+    assert!(dcm.user_device_definitions().contains_key(&identifier));
+
+    dcm.remove_simulated_device(&address);
+
+    assert!(dcm.simulated_devices().is_empty());
+    assert!(!dcm.user_device_definitions().contains_key(&identifier));
   }
 }

--- a/crates/buttplug_server_device_config/src/device_config_manager.rs
+++ b/crates/buttplug_server_device_config/src/device_config_manager.rs
@@ -23,6 +23,7 @@ use crate::{
   ServerDeviceDefinitionBuilder,
   UserDeviceIdentifier,
   SimulatedDeviceConfigEntry,
+  device_config_file::{SimulatedDeviceArchetype, SimulatedDeviceFeatureSummary},
 };
 
 #[derive(Default, Clone)]
@@ -385,5 +386,43 @@ impl DeviceConfigurationManager {
     }
 
     Some(features)
+  }
+
+  pub fn available_simulated_archetypes(&self) -> Vec<SimulatedDeviceArchetype> {
+    self
+      .base_device_definitions
+      .iter()
+      .filter(|(ident, _)| ident.protocol() == "simulated" && ident.identifier().is_some())
+      .map(|(ident, def)| {
+        let identifier = ident
+          .identifier()
+          .as_ref()
+          .expect("filtered for Some above")
+          .clone();
+        let output_features = def
+          .features()
+          .values()
+          .filter(|f| !f.output.is_empty())
+          .map(|f| {
+            let output_type = f
+              .output
+              .iter()
+              .next()
+              .map(|output| output.output_type().to_string())
+              .unwrap_or_default();
+            SimulatedDeviceFeatureSummary {
+              description: f.description.clone(),
+              output_type,
+              index: f.index(),
+            }
+          })
+          .collect();
+        SimulatedDeviceArchetype {
+          identifier,
+          display_name: def.name().clone(),
+          output_features,
+        }
+      })
+      .collect()
   }
 }

--- a/crates/buttplug_server_device_config/src/lib.rs
+++ b/crates/buttplug_server_device_config/src/lib.rs
@@ -143,7 +143,7 @@ extern crate log;
 mod device_config_file;
 
 use buttplug_core::message::OutputType;
-pub use device_config_file::{load_protocol_configs, save_user_config};
+pub use device_config_file::{load_protocol_configs, save_user_config, SimulatedDeviceConfigEntry};
 mod device_config_manager;
 pub use device_config_manager::*;
 mod specifier;

--- a/crates/buttplug_server_device_config/src/lib.rs
+++ b/crates/buttplug_server_device_config/src/lib.rs
@@ -143,7 +143,7 @@ extern crate log;
 mod device_config_file;
 
 use buttplug_core::message::OutputType;
-pub use device_config_file::{load_protocol_configs, save_user_config, SimulatedDeviceConfigEntry};
+pub use device_config_file::{load_protocol_configs, save_user_config, SimulatedDeviceConfigEntry, SimulatedDeviceArchetype, SimulatedDeviceFeatureSummary};
 mod device_config_manager;
 pub use device_config_manager::*;
 mod specifier;

--- a/crates/buttplug_server_device_config/src/specifier.rs
+++ b/crates/buttplug_server_device_config/src/specifier.rs
@@ -381,6 +381,8 @@ pub enum ProtocolCommunicationSpecifier {
   LovenseConnectService(LovenseConnectServiceSpecifier),
   #[serde(rename = "websocket")]
   Websocket(WebsocketSpecifier),
+  #[serde(rename = "simulated")]
+  Simulated(SimulatedSpecifier),
 }
 
 impl PartialEq for ProtocolCommunicationSpecifier {
@@ -396,10 +398,34 @@ impl PartialEq for ProtocolCommunicationSpecifier {
       (LovenseConnectService(self_spec), LovenseConnectService(other_spec)) => {
         self_spec == other_spec
       }
+      (Simulated(self_spec), Simulated(other_spec)) => self_spec == other_spec,
       _ => false,
     }
   }
 }
 
 impl Eq for ProtocolCommunicationSpecifier {
+}
+
+/// Specifier for Simulated Device Manager devices
+///
+/// Used for simulated devices that match archetype names without requiring real hardware.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, Getters, Setters, MutGetters)]
+#[getset(get = "pub", set = "pub")]
+pub struct SimulatedSpecifier {
+  names: HashSet<String>,
+}
+
+impl SimulatedSpecifier {
+  pub fn new(name: &str) -> Self {
+    let mut names = HashSet::new();
+    names.insert(name.to_owned());
+    Self { names }
+  }
+}
+
+impl PartialEq for SimulatedSpecifier {
+  fn eq(&self, other: &Self) -> bool {
+    self.names.intersection(&other.names).count() > 0
+  }
 }

--- a/crates/buttplug_tests/tests/test_simulated_devices.rs
+++ b/crates/buttplug_tests/tests/test_simulated_devices.rs
@@ -89,9 +89,10 @@ async fn test_simulated_1vibe_observation() {
 
 #[tokio::test]
 async fn test_simulated_2vibe_observation() {
-  // AC7.2: Multiple vibrate commands on same device produce observations
-  // Use simulated-1vibe twice to test multiple observations
-  let server = test_server_with_simulated_device("simulated-1vibe", None);
+  // AC7.2: Multi-feature devices produce observations for each feature separately.
+  // Use simulated-2vibe archetype which has 2 vibrate features (feature 0 and feature 1).
+  // Send commands to each feature and verify different feature_index values in observations.
+  let server = test_server_with_simulated_device("simulated-2vibe", None);
 
   let obs_stream = server
     .output_observation_stream()
@@ -130,7 +131,7 @@ async fn test_simulated_2vibe_observation() {
     }
   };
 
-  // Send first vibrate command at value 30
+  // Send vibrate command to feature 0 at value 30
   server
     .parse_message(ButtplugClientMessageVariant::V4(
       OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(30)))
@@ -139,7 +140,7 @@ async fn test_simulated_2vibe_observation() {
     .await
     .unwrap();
 
-  // Verify first observation
+  // Verify first observation for feature 0
   if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
     assert_eq!(obs.device_index, device_index);
     assert_eq!(obs.feature_index, 0);
@@ -149,23 +150,86 @@ async fn test_simulated_2vibe_observation() {
     panic!("Expected first observation but none received or timeout");
   }
 
-  // Send second vibrate command at value 70
+  // Send vibrate command to feature 1 at value 70
   server
     .parse_message(ButtplugClientMessageVariant::V4(
-      OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(70)))
+      OutputCmdV4::new(device_index, 1, OutputCommand::Vibrate(OutputValue::new(70)))
         .into(),
     ))
     .await
     .unwrap();
 
-  // Verify second observation
+  // Verify second observation for feature 1
   if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
     assert_eq!(obs.device_index, device_index);
-    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.feature_index, 1);
     assert_eq!(obs.output_type, "Vibrate");
     assert_eq!(obs.value, 70.0);
   } else {
     panic!("Expected second observation but none received or timeout");
+  }
+}
+
+#[tokio::test]
+async fn test_simulated_rotator_observation() {
+  // AC7.2: Non-vibrate output types (Rotate, Oscillate, Position) produce observations
+  // with the correct output_type string. Use simulated-rotator which has a Rotate feature.
+  let server = test_server_with_simulated_device("simulated-rotator", None);
+
+  let obs_stream = server
+    .output_observation_stream()
+    .expect("should be Some when enabled");
+  pin_mut!(obs_stream);
+
+  // Handshake
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      RequestServerInfoV4::new(
+        "Test",
+        BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+        BUTTPLUG_CURRENT_API_MINOR_VERSION,
+      )
+      .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Start scanning and wait for device
+  let event_stream = server.server_version_event_stream();
+  pin_mut!(event_stream);
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StartScanningV0::default().into(),
+    ))
+    .await
+    .unwrap();
+
+  // Wait for DeviceList event to get device_index
+  let device_index = loop {
+    if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+      if let Some((&idx, _)) = dl.devices().iter().next() {
+        break idx;
+      }
+    }
+  };
+
+  // Send rotate command at value 50 to feature 0 (the rotator's rotate feature)
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      OutputCmdV4::new(device_index, 0, OutputCommand::Rotate(OutputValue::new(50)))
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify observation has correct output_type="Rotate"
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.device_index, device_index);
+    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.output_type, "Rotate");
+    assert_eq!(obs.value, 50.0);
+  } else {
+    panic!("Expected observation but none received or timeout");
   }
 }
 
@@ -200,16 +264,12 @@ async fn test_simulated_diverse_archetypes() {
       .unwrap();
 
     // Verify the device appears
-    let mut device_found = false;
     loop {
       if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
-        if dl.devices().len() > 0 {
-          device_found = true;
-          break;
-        }
+        assert!(!dl.devices().is_empty(), "Archetype {} should be discovered", archetype);
+        break;
       }
     }
-    assert!(device_found, "Archetype {} should be discovered", archetype);
   }
 }
 
@@ -321,15 +381,10 @@ async fn test_simulated_device_appears_on_scan() {
     .unwrap();
 
   // Wait for DeviceList event - device should appear
-  let mut found_device = false;
   loop {
     if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
-      if dl.devices().len() > 0 {
-        // At least one device was discovered
-        found_device = true;
-        break;
-      }
+      assert!(!dl.devices().is_empty(), "Device should appear in DeviceList after scanning");
+      break;
     }
   }
-  assert!(found_device, "Device should appear in DeviceList after scanning");
 }

--- a/crates/buttplug_tests/tests/test_simulated_devices.rs
+++ b/crates/buttplug_tests/tests/test_simulated_devices.rs
@@ -1,0 +1,335 @@
+// Buttplug Rust Source Code File - See https://buttplug.io for more info.
+//
+// Copyright 2016-2026 Nonpolynomial Labs LLC. All rights reserved.
+//
+// Licensed under the BSD 3-Clause license. See LICENSE file in the project root
+// for full license information.
+
+mod util;
+
+use buttplug_core::message::{
+  BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+  BUTTPLUG_CURRENT_API_MINOR_VERSION,
+  ButtplugServerMessageV4,
+  OutputCommand,
+  OutputCmdV4,
+  OutputValue,
+  RequestServerInfoV4,
+  StartScanningV0,
+  StopCmdV4,
+};
+use buttplug_server::message::ButtplugClientMessageVariant;
+use futures::{StreamExt, pin_mut};
+use std::time::Duration;
+use tokio::time::timeout;
+use util::test_server_with_simulated_device;
+
+#[tokio::test]
+async fn test_simulated_1vibe_observation() {
+  // AC7.1, AC7.2: Create a simulated-1vibe, send vibrate command at value 50,
+  // verify observation with correct device_index, feature_index=0, output_type="Vibrate", value=50.0
+  let server = test_server_with_simulated_device("simulated-1vibe", None);
+
+  let obs_stream = server
+    .output_observation_stream()
+    .expect("should be Some when enabled");
+  pin_mut!(obs_stream);
+
+  // Handshake
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      RequestServerInfoV4::new(
+        "Test",
+        BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+        BUTTPLUG_CURRENT_API_MINOR_VERSION,
+      )
+      .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Start scanning and wait for device
+  let event_stream = server.server_version_event_stream();
+  pin_mut!(event_stream);
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StartScanningV0::default().into(),
+    ))
+    .await
+    .unwrap();
+
+  // Wait for DeviceList event to get device_index
+  let device_index = loop {
+    if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+      if let Some((&idx, _)) = dl.devices().iter().next() {
+        break idx;
+      }
+    }
+  };
+
+  // Send vibrate command at value 50
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(50)))
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify observation appears with correct values
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.device_index, device_index);
+    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.output_type, "Vibrate");
+    assert_eq!(obs.value, 50.0);
+  } else {
+    panic!("Expected observation but none received or timeout");
+  }
+}
+
+#[tokio::test]
+async fn test_simulated_2vibe_observation() {
+  // AC7.2: Multiple vibrate commands on same device produce observations
+  // Use simulated-1vibe twice to test multiple observations
+  let server = test_server_with_simulated_device("simulated-1vibe", None);
+
+  let obs_stream = server
+    .output_observation_stream()
+    .expect("should be Some when enabled");
+  pin_mut!(obs_stream);
+
+  // Handshake
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      RequestServerInfoV4::new(
+        "Test",
+        BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+        BUTTPLUG_CURRENT_API_MINOR_VERSION,
+      )
+      .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Start scanning and wait for device
+  let event_stream = server.server_version_event_stream();
+  pin_mut!(event_stream);
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StartScanningV0::default().into(),
+    ))
+    .await
+    .unwrap();
+
+  // Wait for DeviceList event to get device_index
+  let device_index = loop {
+    if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+      if let Some((&idx, _)) = dl.devices().iter().next() {
+        break idx;
+      }
+    }
+  };
+
+  // Send first vibrate command at value 30
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(30)))
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify first observation
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.device_index, device_index);
+    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.output_type, "Vibrate");
+    assert_eq!(obs.value, 30.0);
+  } else {
+    panic!("Expected first observation but none received or timeout");
+  }
+
+  // Send second vibrate command at value 70
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(70)))
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify second observation
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.device_index, device_index);
+    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.output_type, "Vibrate");
+    assert_eq!(obs.value, 70.0);
+  } else {
+    panic!("Expected second observation but none received or timeout");
+  }
+}
+
+#[tokio::test]
+async fn test_simulated_diverse_archetypes() {
+  // AC7.2: Verify various simulated archetypes can be created and discovered
+  // (detailed feature testing happens with 1vibe tests)
+  for archetype in &["simulated-1vibe", "simulated-2vibe", "simulated-rotator", "simulated-oscillator", "simulated-stroker"] {
+    let server = test_server_with_simulated_device(archetype, None);
+
+    // Handshake
+    server
+      .parse_message(ButtplugClientMessageVariant::V4(
+        RequestServerInfoV4::new(
+          "Test",
+          BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+          BUTTPLUG_CURRENT_API_MINOR_VERSION,
+        )
+        .into(),
+      ))
+      .await
+      .unwrap();
+
+    // Start scanning and wait for device
+    let event_stream = server.server_version_event_stream();
+    pin_mut!(event_stream);
+    server
+      .parse_message(ButtplugClientMessageVariant::V4(
+        StartScanningV0::default().into(),
+      ))
+      .await
+      .unwrap();
+
+    // Verify the device appears
+    let mut device_found = false;
+    loop {
+      if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+        if dl.devices().len() > 0 {
+          device_found = true;
+          break;
+        }
+      }
+    }
+    assert!(device_found, "Archetype {} should be discovered", archetype);
+  }
+}
+
+#[tokio::test]
+async fn test_simulated_stop_produces_zero_observation() {
+  // AC7.3: Create a simulated-1vibe, send vibrate at value 50,
+  // then send Stop command, verify the stop produces a zero-value observation
+  let server = test_server_with_simulated_device("simulated-1vibe", None);
+
+  let obs_stream = server
+    .output_observation_stream()
+    .expect("should be Some when enabled");
+  pin_mut!(obs_stream);
+
+  // Handshake
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      RequestServerInfoV4::new(
+        "Test",
+        BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+        BUTTPLUG_CURRENT_API_MINOR_VERSION,
+      )
+      .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Start scanning and wait for device
+  let event_stream = server.server_version_event_stream();
+  pin_mut!(event_stream);
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StartScanningV0::default().into(),
+    ))
+    .await
+    .unwrap();
+
+  // Wait for DeviceList event to get device_index
+  let device_index = loop {
+    if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+      if let Some((&idx, _)) = dl.devices().iter().next() {
+        break idx;
+      }
+    }
+  };
+
+  // Send vibrate command at value 50
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      OutputCmdV4::new(device_index, 0, OutputCommand::Vibrate(OutputValue::new(50)))
+        .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify first observation
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.value, 50.0);
+  } else {
+    panic!("Expected first observation but none received or timeout");
+  }
+
+  // Send StopDeviceCmd for that specific device
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StopCmdV4::new(Some(device_index), None, false, true).into(),
+    ))
+    .await
+    .unwrap();
+
+  // Verify zero-value observation appears
+  if let Ok(Some(obs)) = timeout(Duration::from_millis(500), obs_stream.next()).await {
+    assert_eq!(obs.device_index, device_index);
+    assert_eq!(obs.feature_index, 0);
+    assert_eq!(obs.output_type, "Vibrate");
+    assert_eq!(obs.value, 0.0);
+  } else {
+    panic!("Expected zero-value observation after stop but none received or timeout");
+  }
+}
+
+#[tokio::test]
+async fn test_simulated_device_appears_on_scan() {
+  // AC1.3: Create a server with a simulated device, do handshake + scanning,
+  // verify DeviceList contains the simulated device
+  let server = test_server_with_simulated_device("simulated-1vibe", None);
+
+  // Handshake
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      RequestServerInfoV4::new(
+        "Test",
+        BUTTPLUG_CURRENT_API_MAJOR_VERSION,
+        BUTTPLUG_CURRENT_API_MINOR_VERSION,
+      )
+      .into(),
+    ))
+    .await
+    .unwrap();
+
+  // Start scanning and wait for device
+  let event_stream = server.server_version_event_stream();
+  pin_mut!(event_stream);
+  server
+    .parse_message(ButtplugClientMessageVariant::V4(
+      StartScanningV0::default().into(),
+    ))
+    .await
+    .unwrap();
+
+  // Wait for DeviceList event - device should appear
+  let mut found_device = false;
+  loop {
+    if let Some(ButtplugServerMessageV4::DeviceList(dl)) = event_stream.next().await {
+      if dl.devices().len() > 0 {
+        // At least one device was discovered
+        found_device = true;
+        break;
+      }
+    }
+  }
+  assert!(found_device, "Device should appear in DeviceList after scanning");
+}

--- a/crates/buttplug_tests/tests/util/mod.rs
+++ b/crates/buttplug_tests/tests/util/mod.rs
@@ -191,3 +191,27 @@ pub fn test_server_with_device_and_observations(
 
   (server, device)
 }
+
+#[allow(dead_code)]
+pub fn test_server_with_simulated_device(
+  identifier: &str,
+  display_name: Option<String>,
+) -> ButtplugServer {
+  use buttplug_server::device::hardware::simulated::{
+    SimulatedDeviceEntry, SimulatedHardwareCommunicationManagerBuilder,
+  };
+
+  let device = SimulatedDeviceEntry {
+    identifier: identifier.to_owned(),
+    display_name,
+    address: format!("simulated:test-{}", identifier),
+  };
+
+  let mut dm_builder = ServerDeviceManagerBuilder::new(create_test_dcm());
+  dm_builder.comm_manager(SimulatedHardwareCommunicationManagerBuilder::new(vec![device]));
+  dm_builder.emit_output_observations(true);
+
+  ButtplugServerBuilder::new(dm_builder.finish().unwrap())
+    .finish()
+    .unwrap()
+}

--- a/crates/intiface_engine/src/buttplug_server.rs
+++ b/crates/intiface_engine/src/buttplug_server.rs
@@ -81,6 +81,10 @@ pub fn setup_server_device_comm_managers(
     }
     server_builder.comm_manager(builder);
   }
+  if args.use_simulated_devices() {
+    info!("Including Simulated Device Support");
+    server_builder.add_simulated_devices_if_configured();
+  }
 }
 
 pub async fn reset_buttplug_server(

--- a/crates/intiface_engine/src/options.rs
+++ b/crates/intiface_engine/src/options.rs
@@ -46,6 +46,8 @@ pub struct EngineOptions {
   #[getset(get_copy = "pub")]
   use_device_websocket_server: bool,
   #[getset(get_copy = "pub")]
+  use_simulated_devices: bool,
+  #[getset(get_copy = "pub")]
   device_websocket_server_port: Option<u16>,
   #[getset(get_copy = "pub")]
   crash_main_thread: bool,
@@ -87,6 +89,7 @@ pub struct EngineOptionsExternal {
   pub use_xinput: bool,
   pub use_lovense_connect: bool,
   pub use_device_websocket_server: bool,
+  pub use_simulated_devices: bool,
   pub device_websocket_server_port: Option<u16>,
   pub crash_main_thread: bool,
   pub crash_task_thread: bool,
@@ -120,6 +123,7 @@ impl From<EngineOptionsExternal> for EngineOptions {
       use_xinput: other.use_xinput,
       use_lovense_connect: other.use_lovense_connect,
       use_device_websocket_server: other.use_device_websocket_server,
+      use_simulated_devices: other.use_simulated_devices,
       device_websocket_server_port: other.device_websocket_server_port,
       crash_main_thread: other.crash_main_thread,
       crash_task_thread: other.crash_task_thread,
@@ -220,6 +224,11 @@ impl EngineOptionsBuilder {
 
   pub fn use_device_websocket_server(&mut self, value: bool) -> &mut Self {
     self.options.use_device_websocket_server = value;
+    self
+  }
+
+  pub fn use_simulated_devices(&mut self, value: bool) -> &mut Self {
+    self.options.use_simulated_devices = value;
     self
   }
 

--- a/docs/test-plans/2026-05-19-simulated-device-hwmgr.md
+++ b/docs/test-plans/2026-05-19-simulated-device-hwmgr.md
@@ -1,0 +1,98 @@
+# Human Test Plan: Simulated Device Hardware Manager
+
+## Prerequisites
+
+- Rust toolchain installed (stable, edition 2024)
+- Repository checked out at branch `simulated-device-hwmgr`
+- All automated tests passing:
+  ```bash
+  cargo test -p buttplug_server_device_config
+  cargo test -p buttplug_server
+  cargo test -p buttplug_tests test_simulated
+  ```
+
+## Phase 1: Code Review of simulated.yml Configuration
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1.1 | Open `crates/buttplug_server_device_config/device-config-v4/protocols/simulated.yml` | File exists and is valid YAML |
+| 1.2 | Verify 5 configurations are defined under `configurations:` | Identifiers: `simulated-1vibe`, `simulated-2vibe`, `simulated-rotator`, `simulated-oscillator`, `simulated-stroker` |
+| 1.3 | For each configuration, check the `id` field and all feature `id` fields | All IDs are explicit UUID literals matching the pattern `a1b2c3d4-XXXX-4000-8000-XXXXXXXXXXXX`. No calls to UUID generation functions. |
+| 1.4 | Verify each configuration has the correct feature types: 1vibe has 1 vibrate feature, 2vibe has 2 vibrate features, rotator has 1 rotate feature, oscillator has 1 oscillate feature, stroker has 1 position + 1 hw_position_with_duration feature | Feature types and counts match the descriptions |
+| 1.5 | Verify the `communication:` section lists `simulated:` with all 5 archetype names | Names array contains all 5 identifiers |
+
+## Phase 2: Code Review of SimulatedHardwareInternal
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 2.1 | Open `crates/buttplug_server/src/device/hardware/simulated.rs` | File exists |
+| 2.2 | Inspect `read_value()` method | Returns `Ok(HardwareReading::new(endpoint, &[]))` -- empty byte slice, no error |
+| 2.3 | Inspect `disconnect()` method | Sends `HardwareEvent::Disconnected(address)` on the broadcast channel, returns `Ok(())` |
+| 2.4 | Inspect `write_value()` method | Returns `future::ready(Ok(()))` -- always succeeds, no side effects |
+
+## Phase 3: Code Review of Available Devices API
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 3.1 | Open `crates/buttplug_server_device_config/src/device_config_manager.rs`, find `available_simulated_archetypes()` | Method exists on `DeviceConfigurationManager` |
+| 3.2 | Read the method body | Filters protocol definitions for simulated protocol, extracts identifier, display name, and feature summaries |
+| 3.3 | Verify the returned `SimulatedDeviceArchetype` struct includes: `identifier`, `display_name`, `output_features` | All three fields are present and populated from the config |
+
+## Phase 4: Protocol Handler Review
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 4.1 | Open `crates/buttplug_server/src/device/protocol_impl/simulated.rs` | File exists |
+| 4.2 | Verify `generic_protocol_setup!(SimulatedProtocol, "simulated")` macro invocation | Macro registers the protocol with name "simulated" matching the YAML config |
+| 4.3 | Verify all `handle_output_*_cmd` methods return `Ok(vec![])` | No hardware commands are emitted (no-op), correct for simulated devices |
+
+## End-to-End: Simulated Device Discovery and Command Flow
+
+1. Run `cargo test -p buttplug_tests test_simulated_1vibe_observation -- --nocapture`
+2. Confirm the server performs handshake, starts scanning, and receives a DeviceList containing the simulated device
+3. Confirm a vibrate command succeeds without error
+4. Confirm an OutputObservation is received with `device_index` matching the discovered device, `feature_index=0`, `output_type="Vibrate"`, `value=50.0`
+
+## End-to-End: Multi-Archetype Validation
+
+1. Run `cargo test -p buttplug_tests test_simulated_diverse_archetypes -- --nocapture`
+2. Confirm all 5 archetypes are iterated: simulated-1vibe, simulated-2vibe, simulated-rotator, simulated-oscillator, simulated-stroker
+3. For each archetype, confirm a server is created, scanning discovers exactly one device, and the DeviceList is non-empty
+
+## End-to-End: Error Rejection Pipeline
+
+1. Run `cargo test -p buttplug_server_device_config test_invalid_archetype_rejected -- --nocapture`
+2. Confirm "nonexistent-device" identifier causes `builder.finish()` to return an error
+3. Run `cargo test -p buttplug_server_device_config test_duplicate_address_rejected -- --nocapture`
+4. Confirm two entries with the same address cause `builder.finish()` to return an error
+
+## Human Verification Required
+
+| Criterion | Why Manual | Steps |
+|-----------|------------|-------|
+| AC2.3: Stable UUIDs | UUID stability is a design intent constraint | Review `simulated.yml`: confirm all `id` fields are explicit UUID literals with the `a1b2c3d4-XXXX-4000-8000-*` namespace pattern. Verify no UUID generation code exists in the config pipeline. |
+| AC6.1-6.2: Available archetypes API | No dedicated runtime test | Review `available_simulated_archetypes()` logic. Recommendation: add a unit test asserting 5 entries with non-empty `output_features`. |
+
+## Traceability
+
+| Acceptance Criterion | Automated Test | Manual Step |
+|----------------------|----------------|-------------|
+| AC1.1: Simulated variant | Compile-time | -- |
+| AC1.2: Serialization roundtrip | `user.rs::test_simulated_device_config_roundtrip` | -- |
+| AC1.3: Only SimulatedHWCM matches | `test_simulated_device_appears_on_scan` | -- |
+| AC2.1: simulated.yml parsed | Compile-time + config parsing tests | -- |
+| AC2.2: 5 archetypes defined | `test_simulated_diverse_archetypes` | -- |
+| AC2.3: Stable UUIDs | -- | Phase 1, Steps 1.3-1.4 |
+| AC2.4: generic_protocol_setup! | Compile-time | Phase 4, Steps 4.1-4.3 |
+| AC3.1-3.2: Manager/Builder traits | Compile-time | -- |
+| AC3.3: DeviceFound on scan | `test_simulated_device_appears_on_scan` + unit tests | -- |
+| AC3.4: Device list at construction | All integration tests | -- |
+| AC3.5: can_scan() | Unit tests (with/without devices) | -- |
+| AC4.1-4.6: Hardware implementation | Unit tests (connector, specializer, internal) | Phase 2 |
+| AC5.1-5.5: User config | `test_simulated_device_config_roundtrip`, address/display_name tests | -- |
+| AC6.1-6.3: Available devices API | Compile-time | Phase 3 |
+| AC7.1: Observations emitted | `test_simulated_1vibe_observation` | -- |
+| AC7.2: Correct observation fields | 1vibe, 2vibe, rotator observation tests | -- |
+| AC7.3: Stop produces zero | `test_simulated_stop_produces_zero_observation` | -- |
+| AC8.1: Invalid archetype rejected | `test_invalid_archetype_rejected` | -- |
+| AC8.2: Duplicate address rejected | `test_duplicate_address_rejected` | -- |


### PR DESCRIPTION
## Summary

- **Output Observability**: Opt-in broadcast of `OutputObservation` events for every output command sent to a device, wired from `DeviceHandle` through `ServerDeviceManager`, `ButtplugServer`, `ButtplugRemoteServer`, and up to the frontend as `EngineMessage::DeviceOutputObservation`. Controlled via `EngineOptions::emit_output_observations`.

- **Simulated Device Hardware Manager**: In-process simulated devices for testing the full device lifecycle without real hardware. 5 archetypes (1-vibe, 2-vibe, rotator, oscillator, stroker) configured via user config `simulated_devices` entries. Includes `SimulatedProtocol` (no-op handler), `SimulatedHardwareConnector` (in-memory endpoints), config validation, and `available_simulated_archetypes()` API.

- **`use_simulated_devices` engine option**: Gates the simulated hardware manager in `EngineOptions`, consistent with existing `use_bluetooth_le`/`use_serial_port`/etc. pattern. Removes implicit auto-wiring from `ServerDeviceManagerBuilder::finish()` in favour of explicit opt-in.

- **HID crash fix**: Calls `hid_exit()` on macOS to prevent crash on HID manager drop.

## Test plan

- [x] Integration tests for output observations (`test_output_observations.rs`)
- [x] Integration tests for simulated devices (`test_simulated_devices.rs`)
- [x] Config validation tests (invalid archetypes, duplicate addresses)
- [x] `cargo test` passes
- [x] `cargo build` clean
- [ ] Manual verification with Intiface Central (simulated devices appear in device list when `use_simulated_devices` enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)