### PR TITLE
Remove old docs metadata resulting in broken docs builds for some crates

### DIFF
--- a/crates/buttplug_core/Cargo.toml
+++ b/crates/buttplug_core/Cargo.toml
@@ -23,12 +23,6 @@ default=["tokio-runtime"]
 tokio-runtime=["tokio/rt", "tokio/time"]
 wasm=["wasm-bindgen-futures", "wasmtimer"]
 
-# Only build docs on one platform (linux)
-[package.metadata.docs.rs]
-targets = []
-# Features to pass to Cargo (default: [])
-features = ["default", "unstable"]
-
 [dev-dependencies]
 tracing-subscriber = "0.3.23"
 

--- a/crates/buttplug_server_hwmgr_lovense_connect/Cargo.toml
+++ b/crates/buttplug_server_hwmgr_lovense_connect/Cargo.toml
@@ -18,14 +18,6 @@ test = true
 doctest = true
 doc = true
 
-
-
-# Only build docs on one platform (linux)
-[package.metadata.docs.rs]
-targets = []
-# Features to pass to Cargo (default: [])
-features = ["default", "unstable"]
-
 [dependencies]
 buttplug_core = { version = "11.0.0", path = "../buttplug_core", default-features = false }
 buttplug_server = { version = "11.0.0", path = "../buttplug_server", default-features = false }

--- a/crates/buttplug_server_hwmgr_websocket/Cargo.toml
+++ b/crates/buttplug_server_hwmgr_websocket/Cargo.toml
@@ -18,14 +18,6 @@ test = true
 doctest = true
 doc = true
 
-
-
-# Only build docs on one platform (linux)
-[package.metadata.docs.rs]
-targets = []
-# Features to pass to Cargo (default: [])
-features = ["default", "unstable"]
-
 [dependencies]
 buttplug_core = { version = "11.0.0", path = "../buttplug_core", default-features = false }
 buttplug_server = { version = "11.0.0", path = "../buttplug_server", default-features = false }


### PR DESCRIPTION
An old feature flag was resulting in docs.rs failing to build documentation for some crates, buttplug_core being one of the big ones. Rather than simply correcting this, as all other crates have the metadata entirely removed, I've done so here too.