### PR TITLE
fix(device-config): add missing Anello motor

### DIFF
--- a/crates/buttplug_server_device_config/build-config/buttplug-device-config-v5.json
+++ b/crates/buttplug_server_device_config/build-config/buttplug-device-config-v5.json
@@ -1,7 +1,7 @@
 {
   "version": {
     "major": 5,
-    "minor": 30
+    "minor": 31
   },
   "protocols": {
     "activejoy": {
@@ -4933,6 +4933,50 @@
           "name": "Honey Play Box Pleasure Pivot"
         },
         {
+          "features": [
+            {
+              "id": "3d0f4e2e-8f23-4cf6-8b62-7c6cc1ed5a58",
+              "index": 0,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            },
+            {
+              "id": "6a2a1af6-1c1b-43d6-86dc-cf1d7db1a6d8",
+              "index": 1,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            },
+            {
+              "description": "Battery Level",
+              "id": "5ec5bb6f-e6ef-4f9c-9fd3-13e88c8011f0",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
+                  ]
+                }
+              }
+            }
+          ],
           "id": "0a9c43fb-2d58-4af9-aef2-60f48c6e7707",
           "identifier": [
             "HPB-296"

--- a/crates/buttplug_server_device_config/device-config/protocols/honeyplaybox.yml
+++ b/crates/buttplug_server_device_config/device-config/protocols/honeyplaybox.yml
@@ -35,6 +35,31 @@ configurations:
   - identifier:
       - HPB-296
     name: Honey Play Box Anello
+    features:
+      - id: 3d0f4e2e-8f23-4cf6-8b62-7c6cc1ed5a58
+        output:
+          vibrate:
+            value:
+              - 0
+              - 100
+        index: 0
+      - id: 6a2a1af6-1c1b-43d6-86dc-cf1d7db1a6d8
+        output:
+          vibrate:
+            value:
+              - 0
+              - 100
+        index: 1
+      - description: Battery Level
+        id: 5ec5bb6f-e6ef-4f9c-9fd3-13e88c8011f0
+        input:
+          battery:
+            value:
+              - - 0
+                - 100
+            command:
+              - Read
+        index: 2
     id: 0a9c43fb-2d58-4af9-aef2-60f48c6e7707
   - identifier:
       - HBP-JXT001

--- a/crates/buttplug_server_device_config/device-config/version.yaml
+++ b/crates/buttplug_server_device_config/device-config/version.yaml
@@ -1,3 +1,3 @@
 version:
   major: 5
-  minor: 30
+  minor: 31


### PR DESCRIPTION
## Summary

- Fix the HoneyPlayBox Anello device configuration.
- Add support for independently controlling both motors.
- Correct the previous configuration, which incorrectly described the device as having only one motor.

## Background

This update addresses user feedback indicating that the Honey Play Box Anello has two independently controllable motors. The previous device definition exposed only a single vibration feature due to an incorrect configuration.

## Testing

- Regenerated the device configuration from the YAML source.
- Ran the device configuration test suite successfully.