### PR TITLE
feat:Add Honey Play Box Kaipro support

### DIFF
--- a/crates/buttplug_server/src/device/protocol_impl/honeyplaybox.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/honeyplaybox.rs
@@ -45,9 +45,6 @@ const HONEY_PLAYBOX_KEEPALIVE_DELAY: u64 = 500;
 const HONEY_PLAYBOX_COMMAND_RETRY: u64 = 3;
 const HONEY_PLAYBOX_PROTOCOL_UUID: Uuid = uuid!("0d1598bd-6845-4950-8aa0-416b1115fc7c");
 
-type ConstrictCommandHandler =
-  fn(&HoneyPlayBox, u32, u32) -> Result<Vec<HardwareCommand>, ButtplugDeviceError>;
-
 // The secret key used for MD5 signing.
 const SECRET: [u8; 16] = [
   0x8b, 0xe3, 0xfd, 0x04, 0x68, 0x35, 0x09, 0x86, 0x12, 0x1a, 0xbf, 0x03, 0x30, 0xe9, 0xe3, 0xc5,
@@ -65,10 +62,6 @@ impl ProtocolInitializer for HoneyPlayBoxInitializer {
     hardware: Arc<Hardware>,
     device_definition: &ServerDeviceDefinition,
   ) -> Result<Arc<dyn ProtocolHandler>, ButtplugDeviceError> {
-    let constrict_handler: Option<ConstrictCommandHandler> = match hardware.name().as_str() {
-      "HPB-274" => Some(HoneyPlayBox::handle_kaipro_constrict_cmd),
-      _ => None,
-    };
     let feature_count = device_definition
       .features()
       .values()
@@ -111,7 +104,7 @@ impl ProtocolInitializer for HoneyPlayBoxInitializer {
                             trace!("HoneyPlayBox handshake success on attempt {}", count+1);
                             if let Some(rand) = FrameCodec::extract_random(&frame) {
                                 info!("HoneyPlayBox handshake random token {:?}", rand.clone());
-                                return Ok(Arc::new(HoneyPlayBox::new(hardware, rand, feature_count, counter, constrict_handler)));
+                                return Ok(Arc::new(HoneyPlayBox::new(hardware, rand, feature_count, counter)));
                             }
                             warn!("HoneyPlayBox: No random token in frame (handshake attempt {})", count+1);
                         }
@@ -157,7 +150,6 @@ pub struct HoneyPlayBox {
   last_command: Arc<Vec<AtomicU8>>,
   packet_id: Arc<AtomicU8>,
   last_send: Arc<RwLock<Instant>>,
-  constrict_handler: Option<ConstrictCommandHandler>,
 }
 
 async fn hpb_keepalive(
@@ -217,13 +209,7 @@ async fn hpb_keepalive(
 }
 
 impl HoneyPlayBox {
-  fn new(
-    hardware: Arc<Hardware>,
-    random_key: [u8; 16],
-    feature_count: usize,
-    count: u8,
-    constrict_handler: Option<ConstrictCommandHandler>,
-  ) -> Self {
+  fn new(hardware: Arc<Hardware>, random_key: [u8; 16], feature_count: usize, count: u8) -> Self {
     let last_command = Arc::new(
       (0..feature_count)
         .map(|_| AtomicU8::new(0))
@@ -247,16 +233,7 @@ impl HoneyPlayBox {
       last_command,
       packet_id,
       last_send,
-      constrict_handler,
     }
-  }
-
-  fn handle_kaipro_constrict_cmd(
-    &self,
-    feature_index: u32,
-    level: u32,
-  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
-    self.send_command(feature_index, if level == 0 { 0 } else { level + 100 })
   }
 
   fn send_command(
@@ -334,11 +311,7 @@ impl ProtocolHandler for HoneyPlayBox {
     _feature_id: Uuid,
     level: u32,
   ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
-    if let Some(handler) = self.constrict_handler {
-      handler(self, feature_index, level)
-    } else {
-      self.command_unimplemented("OutputCmd (Constrict Actuator)")
-    }
+    self.send_command(feature_index, if level == 0 { 0 } else { level + 100 })
   }
 
   fn handle_battery_level_cmd(

--- a/crates/buttplug_server/src/device/protocol_impl/honeyplaybox.rs
+++ b/crates/buttplug_server/src/device/protocol_impl/honeyplaybox.rs
@@ -45,6 +45,9 @@ const HONEY_PLAYBOX_KEEPALIVE_DELAY: u64 = 500;
 const HONEY_PLAYBOX_COMMAND_RETRY: u64 = 3;
 const HONEY_PLAYBOX_PROTOCOL_UUID: Uuid = uuid!("0d1598bd-6845-4950-8aa0-416b1115fc7c");
 
+type ConstrictCommandHandler =
+  fn(&HoneyPlayBox, u32, u32) -> Result<Vec<HardwareCommand>, ButtplugDeviceError>;
+
 // The secret key used for MD5 signing.
 const SECRET: [u8; 16] = [
   0x8b, 0xe3, 0xfd, 0x04, 0x68, 0x35, 0x09, 0x86, 0x12, 0x1a, 0xbf, 0x03, 0x30, 0xe9, 0xe3, 0xc5,
@@ -62,6 +65,10 @@ impl ProtocolInitializer for HoneyPlayBoxInitializer {
     hardware: Arc<Hardware>,
     device_definition: &ServerDeviceDefinition,
   ) -> Result<Arc<dyn ProtocolHandler>, ButtplugDeviceError> {
+    let constrict_handler: Option<ConstrictCommandHandler> = match hardware.name().as_str() {
+      "HPB-274" => Some(HoneyPlayBox::handle_kaipro_constrict_cmd),
+      _ => None,
+    };
     let feature_count = device_definition
       .features()
       .values()
@@ -104,7 +111,7 @@ impl ProtocolInitializer for HoneyPlayBoxInitializer {
                             trace!("HoneyPlayBox handshake success on attempt {}", count+1);
                             if let Some(rand) = FrameCodec::extract_random(&frame) {
                                 info!("HoneyPlayBox handshake random token {:?}", rand.clone());
-                                return Ok(Arc::new(HoneyPlayBox::new(hardware, rand, feature_count, counter)));
+                                return Ok(Arc::new(HoneyPlayBox::new(hardware, rand, feature_count, counter, constrict_handler)));
                             }
                             warn!("HoneyPlayBox: No random token in frame (handshake attempt {})", count+1);
                         }
@@ -150,6 +157,7 @@ pub struct HoneyPlayBox {
   last_command: Arc<Vec<AtomicU8>>,
   packet_id: Arc<AtomicU8>,
   last_send: Arc<RwLock<Instant>>,
+  constrict_handler: Option<ConstrictCommandHandler>,
 }
 
 async fn hpb_keepalive(
@@ -209,7 +217,13 @@ async fn hpb_keepalive(
 }
 
 impl HoneyPlayBox {
-  fn new(hardware: Arc<Hardware>, random_key: [u8; 16], feature_count: usize, count: u8) -> Self {
+  fn new(
+    hardware: Arc<Hardware>,
+    random_key: [u8; 16],
+    feature_count: usize,
+    count: u8,
+    constrict_handler: Option<ConstrictCommandHandler>,
+  ) -> Self {
     let last_command = Arc::new(
       (0..feature_count)
         .map(|_| AtomicU8::new(0))
@@ -233,7 +247,16 @@ impl HoneyPlayBox {
       last_command,
       packet_id,
       last_send,
+      constrict_handler,
     }
+  }
+
+  fn handle_kaipro_constrict_cmd(
+    &self,
+    feature_index: u32,
+    level: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    self.send_command(feature_index, if level == 0 { 0 } else { level + 100 })
   }
 
   fn send_command(
@@ -303,6 +326,19 @@ impl ProtocolHandler for HoneyPlayBox {
     speed: i32,
   ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
     self.send_command(feature_index, speed.unsigned_abs())
+  }
+
+  fn handle_output_constrict_cmd(
+    &self,
+    feature_index: u32,
+    _feature_id: Uuid,
+    level: u32,
+  ) -> Result<Vec<HardwareCommand>, ButtplugDeviceError> {
+    if let Some(handler) = self.constrict_handler {
+      handler(self, feature_index, level)
+    } else {
+      self.command_unimplemented("OutputCmd (Constrict Actuator)")
+    }
   }
 
   fn handle_battery_level_cmd(

--- a/crates/buttplug_server_device_config/build-config/buttplug-device-config-v5.json
+++ b/crates/buttplug_server_device_config/build-config/buttplug-device-config-v5.json
@@ -1,7 +1,7 @@
 {
   "version": {
     "major": 5,
-    "minor": 30
+    "minor": 31
   },
   "protocols": {
     "activejoy": {
@@ -4878,6 +4878,7 @@
           "btle": {
             "names": [
               "JXT002",
+              "HPB-274",
               "HPB-393-1",
               "HPB-0520",
               "HONEY-835",
@@ -4931,6 +4932,59 @@
             "HPB-398"
           ],
           "name": "Honey Play Box Pleasure Pivot"
+        },
+        {
+          "features": [
+            {
+              "description": "Vibrator",
+              "id": "06456fc9-9ab6-425b-9cf1-9f875d21bcf3",
+              "index": 0,
+              "output": {
+                "vibrate": {
+                  "value": [
+                    0,
+                    100
+                  ]
+                }
+              }
+            },
+            {
+              "description": "Suction Pump",
+              "id": "09817707-f6b8-44de-8708-58101999396a",
+              "index": 1,
+              "output": {
+                "constrict": {
+                  "value": [
+                    0,
+                    4
+                  ]
+                }
+              }
+            },
+            {
+              "description": "Battery Level",
+              "id": "97528990-df35-4fa1-8f3c-f6f78b1b8538",
+              "index": 2,
+              "input": {
+                "battery": {
+                  "command": [
+                    "Read"
+                  ],
+                  "value": [
+                    [
+                      0,
+                      100
+                    ]
+                  ]
+                }
+              }
+            }
+          ],
+          "id": "b33a5de9-d0c6-448b-8150-e402dd29ed4d",
+          "identifier": [
+            "HPB-274"
+          ],
+          "name": "Honey Play Box Kaipro"
         },
         {
           "id": "0a9c43fb-2d58-4af9-aef2-60f48c6e7707",

--- a/crates/buttplug_server_device_config/device-config/protocols/honeyplaybox.yml
+++ b/crates/buttplug_server_device_config/device-config/protocols/honeyplaybox.yml
@@ -33,6 +33,37 @@ configurations:
     name: Honey Play Box Pleasure Pivot
     id: c205e707-9561-4016-97aa-0bde609b0edc
   - identifier:
+      - HPB-274
+    name: Honey Play Box Kaipro
+    features:
+      - description: Vibrator
+        id: 06456fc9-9ab6-425b-9cf1-9f875d21bcf3
+        output:
+          vibrate:
+            value:
+              - 0
+              - 100
+        index: 0
+      - description: Suction Pump
+        id: 09817707-f6b8-44de-8708-58101999396a
+        output:
+          constrict:
+            value:
+              - 0
+              - 4
+        index: 1
+      - description: Battery Level
+        id: 97528990-df35-4fa1-8f3c-f6f78b1b8538
+        input:
+          battery:
+            value:
+              - - 0
+                - 100
+            command:
+              - Read
+        index: 2
+    id: b33a5de9-d0c6-448b-8150-e402dd29ed4d
+  - identifier:
       - HPB-296
     name: Honey Play Box Anello
     id: 0a9c43fb-2d58-4af9-aef2-60f48c6e7707
@@ -485,6 +516,7 @@ communication:
   - btle:
       names:
         - JXT002
+        - HPB-274
         - HPB-393-1
         - HPB-0520
         - HONEY-835

--- a/crates/buttplug_server_device_config/device-config/version.yaml
+++ b/crates/buttplug_server_device_config/device-config/version.yaml
@@ -1,3 +1,3 @@
 version:
   major: 5
-  minor: 30
+  minor: 31


### PR DESCRIPTION
## Summary

Adds support for the Honey Play Box Kaipro (`HPB-274`).

- Adds vibration control with levels from 0 to 100.
- Adds constrict control with four modes.
- Maps constrict level 0 to stop and levels 1–4 to device command values 101–104.
- Keeps the Kaipro-specific command handling isolated from other Honey Play Box devices.

## Testing

- Verified formatting and compilation.
- Passed device configuration tests.