### PR TITLE
fix(webbluetooth): read characteristic values via the DataView's buffer

### DIFF
--- a/crates/buttplug_server_hwmgr_webbluetooth/src/webbluetooth_hardware.rs
+++ b/crates/buttplug_server_hwmgr_webbluetooth/src/webbluetooth_hardware.rs
@@ -297,9 +297,20 @@ async fn run_webbluetooth_loop(
               ))
             })
             .map(|val| {
-              let data_view = val;
+              // readValue resolves to a DataView. `Uint8Array::new(dataView)`
+              // treats it as array-like (length undefined) => empty array =>
+              // copy_to length assert panics and kills the wasm instance.
+              // Build the view over the underlying buffer instead (as the
+              // Subscribe handler below does), honoring the DataView's
+              // byte offset/length.
+              let data_view = js_sys::DataView::from(val);
               let mut body = vec![0u8; data_view.byte_length()];
-              Uint8Array::new(&data_view).copy_to(&mut body[..]);
+              Uint8Array::new_with_byte_offset_and_length(
+                &JsValue::from(data_view.buffer()),
+                data_view.byte_offset() as u32,
+                data_view.byte_length() as u32,
+              )
+              .copy_to(&mut body[..]);
               HardwareReading::new(read_cmd.endpoint(), &body)
             });
           let _ = reply.send(result);


### PR DESCRIPTION
Fixes #941 (maintainer green-lit the PR in the issue thread).

## Problem

In the `WebBluetoothDeviceCommand::Read` handler, `readValue()` resolves to a **DataView**, but the bytes were extracted with `Uint8Array::new(&data_view)`. In JS, `new Uint8Array(dataView)` treats the DataView as a plain array-like (`length === undefined`), producing an **empty** array. The subsequent `copy_to` then trips js-sys's length assertion and panics, killing the whole wasm instance:

```
panicked at js-sys-0.3.104/src/lib.rs:14143:1:
assertion `left == right` failed
  left: 0
 right: 15
Uncaught RuntimeError: unreachable
```

Net effect: any protocol that performs a hardware read during init dies silently right after chooser pairing, and the embedded server is dead from that point on. Native btleplug paths are unaffected, which makes this confusing to diagnose from the outside.

## Fix

Build the `Uint8Array` over the DataView's underlying `buffer()`, honoring its byte offset/length — the Subscribe notification handler already uses the buffer-based pattern. One expression changed, plus a comment explaining why `Uint8Array::new` must not be used here.

## Verification

- `cargo check -p buttplug_server_hwmgr_webbluetooth --target wasm32-unknown-unknown` passes.
- Verified against a physical Sensee Capsule (`CCPA10S2`, protocol `sensee-v2`, which reads model data from Tx during init) on Chrome/macOS: with this patch in our wasm build, the device identifies and runs (vibrate + constrict) through the browser embedded server; without it, the panic above reproduces 100% after pairing.
